### PR TITLE
HT-2256 Review should not submit if reviewer hits Enter after typing …

### DIFF
--- a/cgi/partial/crownCopyrightForm.tt
+++ b/cgi/partial/crownCopyrightForm.tt
@@ -116,6 +116,7 @@
      onfocus="document.getElementById('NoteTextField').focus()">.</a>
 </div>
 <div id="SubmitForm">
+  <button type="submit" disabled style="display: none" aria-hidden="true"></button>
   <table>
     <tr>
       <td><input class="review" type="submit" name="submit" value="Submit" accesskey="s"/></td>


### PR DESCRIPTION
…pub date

Arguably a standards-compliant-ish way to prevent Enter from submitting a form: https://stackoverflow.com/a/51507806