### PR TITLE
Add .travis.yml to piggyback CI off Docker configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: minimal
+
+git:
+  submodules: false
+
+services:
+  - docker
+
+before_install:
+  - docker-compose build
+
+script:
+  - docker-compose run test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,4 +21,4 @@ services:
       - mariadb
     links:
       - mariadb
-    command: bash -c "cd /htapps/babel/crms && perl Makefile.PL && bin/wait-for --timeout=60 mariadb:3306 -- make test"
+    command: bash -c "cd /htapps/babel/crms && perl Makefile.PL && bin/wait-for --timeout=60 mariadb:3306 -- make test TEST_VERBOSE=1"


### PR DESCRIPTION
I don't know why there are two Travis notifications. Travis has been acting up lately (not synchronizing GitHub organizations, blank logs) so maybe this is just another ephemeral "glitch."