### PR TITLE
Add SET NAMES "utf8"

### DIFF
--- a/bin/institutions.pl
+++ b/bin/institutions.pl
@@ -65,7 +65,7 @@ END
 
 my $n = CheckInstitutions();
 $msg =~ s/__N__/$n/g;
-$msg =~ s/__OUTFILE__/$outfile_instid/g;
+$msg =~ s/__OUTFILE_INSTID__/$outfile_instid/g;
 $msg =~ s/__OUTFILE_ENTITYID__/$outfile_entityid/g;
 
 if ($noop)

--- a/cgi/CRMS.pm
+++ b/cgi/CRMS.pm
@@ -429,6 +429,7 @@ sub ConnectToSdrDb
   {
     $sdr_dbh->{mysql_auto_reconnect} = 1;
     $sdr_dbh->{mysql_enable_utf8} = 1;
+    $sdr_dbh->do('SET NAMES "utf8";');
   }
   else
   {


### PR DESCRIPTION
For HT databases to fix `institutions.pl` encoding issue for Keio name entry.