### PR TITLE
DEV-332 CRMS .rights Files Need to be UTF-8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 *.pm.tdy
 *.bs
 
+# Keep prep/ directory for testing but ignore any contents
+prep/
+
 # Devel::Cover
 cover_db/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
-FROM debian:buster
+FROM debian:bullseye
 
 RUN sed -i 's/main.*/main contrib non-free/' /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y \
   perl \
-  imagemagick \
   libxerces-c3.2 \
   libxerces-c3-dev \
   sqlite3 \
@@ -127,8 +126,7 @@ RUN apt-get update && apt-get install -y \
   libyaml-appconfig-perl \
   libyaml-libyaml-perl \
   libyaml-perl \
-  perlmagick \
-  libmarc-record-perl\
+  libmarc-record-perl \
   libmarc-xml-perl
 
 RUN apt-get install -y \
@@ -152,22 +150,8 @@ RUN apt-get install -y \
   libperl-critic-perl
 
 RUN cpan \
-  File::Value \
-  File::ANVL \
-  File::Namaste \
-  File::Pairtree \
   CGI::Application::Plugin::Routes \
-  Algorithm::LUHN \
   OAuth::Lite \
-  EBook::EPUB \
-  Sub::Uplevel \
-  Test::Exception \
-  Devel::Cycle \
-  Test::Memory::Cycle \
-  Mozilla::CA
+  Test::Exception
 
-RUN mkdir /htapps
-RUN mkdir /htapps/babel
-RUN mkdir /htapps/babel/crms
-RUN mkdir /htapps/babel/crms/prep
-
+RUN mkdir -p /htapps/babel/crms

--- a/cgi/CRMS.pm
+++ b/cgi/CRMS.pm
@@ -1142,7 +1142,7 @@ sub WriteRightsFile
   }
   my $temp = $perm . '.tmp';
   if (-f $temp) { die "file already exists: $temp\n"; }
-  open (my $fh, '>', $temp) || die "failed to open rights file ($temp): $!\n";
+  open (my $fh, '>:utf8', $temp) || die "failed to open rights file ($temp): $!\n";
   print $fh $rights;
   close $fh;
   rename $temp, $perm;

--- a/cgi/Licensing.pm
+++ b/cgi/Licensing.pm
@@ -163,7 +163,7 @@ sub rights_data {
     my $note = $ticket || '';
     if ($rights_holder) {
       $note .= ' ' if length $note;
-      $note .= " ($rights_holder)" if $rights_holder;
+      $note .= "($rights_holder)";
     }
     $retval->{rights_data} .= join("\t", ($htid, $crms->TranslateAttr($attr),
                                    $crms->TranslateReason($reason),

--- a/t/CRMS.t
+++ b/t/CRMS.t
@@ -2,6 +2,7 @@
 
 use strict;
 use warnings;
+use utf8;
 BEGIN { unshift(@INC, $ENV{'SDRROOT'}. '/crms/cgi'); }
 
 use Test::More;
@@ -9,6 +10,18 @@ use Test::More;
 require_ok($ENV{'SDRROOT'}. '/crms/cgi/CRMS.pm');
 my $cgi = CGI->new();
 my $crms = CRMS->new('cgi' => $cgi, 'verbose' => 0);
-ok(defined $crms);
+ok(defined $crms, 'CRMS object created');
+test_WriteRightsFile();
 done_testing();
 
+sub test_WriteRightsFile {
+  my $rights_data = join "\t", ('mdp.001', '1', '1', 'crms', 'null', '鬼塚英吉');
+  $crms->WriteRightsFile($rights_data);
+  my $path = $crms->get('export_path');
+  ok(-f $path, "WriteRightsFile export path exists");
+  open my $fh, '<:encoding(UTF-8)', $path;
+  read $fh, my $buffer, -s $path;
+  my @fields = split "\t", $buffer;
+  is($fields[5], '鬼塚英吉', "WriteRightsFile Unicode characters survive round trip");
+  close $fh;
+}

--- a/t/Licensing.t
+++ b/t/Licensing.t
@@ -46,7 +46,6 @@ foreach my $reason (@$reasons)
 }
 
 ###==== rights_data() ====###
-# FIXME: we need a Faker-heavy DB setup routine so we don't have to do this here.
 $crms->PrepareSubmitSql('DELETE FROM licensing');
 my $sql = 'INSERT INTO institutions (name,shortname,suffix) VALUES ("Test Institution", "Test", "test.edu")';
 $crms->PrepareSubmitSql($sql);
@@ -62,7 +61,7 @@ $sql = 'INSERT INTO licensing (htid,user,attr,reason,ticket,rights_holder)'.
 $crms->PrepareSubmitSql($sql);
 $data = $licensing->rights_data();
 is(scalar @{$data->{ids}}, 1, 'Licensing->rights_data returns one entry');
-ok($data->{rights_data} =~ m/HT-0000 \s\(Nobody\)/, 'Licensing->rights_data returns properly-formatted note');
+ok($data->{rights_data} =~ m/HT-0000 \(Nobody\)/, 'Licensing->rights_data returns properly-formatted note');
 $crms->PrepareSubmitSql('DELETE FROM licensing WHERE ticket="HT-0000"');
 $crms->PrepareSubmitSql('DELETE FROM users WHERE id="test_user"');
 $crms->PrepareSubmitSql('DELETE FROM institutions WHERE name="Test Institution"');


### PR DESCRIPTION
- .rights files encoded as UTF-8.
- Use Debian Bullseye for image base.