### PR TITLE
DEV-511 add actions to deploy to k8s

### DIFF
--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -1,0 +1,23 @@
+name: Build latest from main and deploy to staging
+
+on:
+  workflow_run:
+    workflows: [ 'Run Tests']
+    branches: [ 'main' ]
+    types: [ completed ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: hathitrust/github_actions/build@v1
+        with:
+          image: ghcr.io/${{ github.repository }}-unstable
+          dockerfile: Dockerfile.prod
+          tag: ${{ github.sha }}
+          push_latest: true
+          registry_token: ${{ github.token }}

--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -1,0 +1,26 @@
+name: Deploy to Production
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release
+        required: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+    - name: Deploy overnight Cronjob to Production
+      uses: mlibrary/deploy-to-kubernetes@v3
+      with:
+        registry_token: ${{ secrets.GITHUB_TOKEN }}
+        image: ghcr.io/${{ github.repository }}:${{ github.event.inputs.tag }}
+        cluster_ca: ${{ secrets.KUBERNETES_CA }}
+        cluster_server: ${{ secrets.KUBERNETES_SERVER }}
+        namespace_token: ${{ secrets.KUBERNETES_TOKEN }}
+        namespace: ${{ secrets.KUBERNETES_NAMESPACE }}
+        resource_type: cronjob
+        resource_name: overnight
+        container: overnight

--- a/.github/workflows/manual-deploy-testing.yaml
+++ b/.github/workflows/manual-deploy-testing.yaml
@@ -1,0 +1,52 @@
+---
+name: Manual Deploy to Testing
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: tag
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: hathitrust/github_actions/build@v1
+        with:
+          dockerfile: Dockerfile.prod
+          image: ghcr.io/${{ github.repository }}-unstable
+          tag: ${{ github.event.inputs.tag }}
+          push_latest: false
+          registry_token: ${{ github.token }}
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: testing
+    steps:
+      - name: Clone latest repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.tag }}
+      - name: Find commit for tag
+        id: tag_check
+        uses: hathitrust/github_actions/validate-tag@v1
+        with:
+          tag: ${{ github.event.inputs.tag }}
+      - name: Deploy to testing
+        uses: mlibrary/deploy-to-kubernetes@v3
+        with:
+          registry_token: ${{ github.token }}
+          image: ghcr.io/${{ github.repository }}-unstable:${{ steps.tag_check.outputs.tag }}
+          cluster_ca: ${{ secrets.KUBERNETES_CA }}
+          cluster_server: ${{ secrets.KUBERNETES_SERVER }}
+          namespace_token: ${{ secrets.KUBERNETES_TOKEN }}
+          namespace: ${{ secrets.KUBERNETES_NAMESPACE }}
+          resource_type: cronjob
+          resource_name: overnight
+          container: overnight

--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -1,0 +1,17 @@
+---
+name: Docker Tag Latest Release
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  tag-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: hathitrust/github_actions/tag-release@v1
+        with:
+          registry_token: ${{ github.token }}
+          existing_tag: ghcr.io/${{ github.repository }}-unstable:${{ github.sha }}
+          image: ghcr.io/${{ github.repository }}
+          new_tag: ${{ github.event.release.tag_name }}

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,0 +1,161 @@
+FROM debian:bullseye
+
+RUN sed -i 's/main.*/main contrib non-free/' /etc/apt/sources.list
+
+RUN apt-get update && apt-get install -y \
+  perl \
+  libxerces-c3.2 \
+  libxerces-c3-dev \
+  sqlite3 \
+  file \
+  libalgorithm-diff-xs-perl \
+  libany-moose-perl \
+  libapache-session-perl \
+  libarchive-zip-perl \
+  libcapture-tiny-perl \
+  libcgi-application-perl \
+  libcgi-compile-perl \
+  libcgi-emulate-psgi-perl \
+  libcgi-psgi-perl \
+  libclass-accessor-perl \
+  libclass-c3-perl \
+  libclass-data-accessor-perl \
+  libclass-data-inheritable-perl \
+  libclass-errorhandler-perl \
+  libclass-load-perl \
+  libcommon-sense-perl \
+  libcompress-raw-zlib-perl \
+  libconfig-auto-perl \
+  libconfig-inifiles-perl \
+  libconfig-tiny-perl \
+  libcrypt-openssl-random-perl \
+  libcrypt-openssl-rsa-perl \
+  libcrypt-ssleay-perl \
+  libdata-optlist-perl \
+  libdata-page-perl \
+  libdate-calc-perl \
+  libdate-manip-perl \
+  libdbd-mock-perl \
+  libdbd-mysql-perl \
+  libdbd-sqlite3-perl \
+  libdevel-globaldestruction-perl \
+  libdigest-sha-perl \
+  libemail-date-format-perl \
+  libencode-locale-perl \
+  liberror-perl \
+  libeval-closure-perl \
+  libexcel-writer-xlsx-perl \
+  libfcgi-perl \
+  libfcgi-procmanager-perl \
+  libfile-listing-perl \
+  libfile-slurp-perl \
+  libfilesys-df-perl \
+  libgeo-ip-perl \
+  libhtml-parser-perl \
+  libhtml-tree-perl \
+  libhttp-browserdetect-perl \
+  libhttp-cookies-perl \
+  libhttp-daemon-perl \
+  libhttp-date-perl \
+  libhttp-dav-perl \
+  libhttp-message-perl \
+  libhttp-negotiate-perl \
+  libimage-exiftool-perl \
+  libimage-info-perl \
+  libimage-size-perl \
+  libinline-perl \
+  libio-html-perl \
+  libio-socket-ssl-perl \
+  libio-string-perl \
+  libipc-run-perl \
+  libjson-perl \
+  libjson-pp-perl \
+  libjson-xs-perl \
+  liblist-compare-perl \
+  liblist-moreutils-perl \
+  liblog-log4perl-perl \
+  liblwp-authen-oauth2-perl \
+  liblwp-mediatypes-perl \
+  libmail-sendmail-perl \
+  libmailtools-perl \
+  libmarc-record-perl \
+  libmarc-xml-perl \
+  libmime-lite-perl \
+  libmime-types-perl \
+  libmodule-implementation-perl \
+  libmodule-runtime-perl \
+  libmoose-perl \
+  libmouse-perl \
+  libmro-compat-perl \
+  libnet-dns-perl \
+  libnet-http-perl \
+  libnet-libidn-perl \
+  libnet-oauth-perl \
+  libnet-ssleay-perl \
+  libpackage-deprecationmanager-perl \
+  libpackage-stash-perl \
+  libparse-recdescent-perl \
+  libplack-perl \
+  libpod-simple-perl \
+  libproc-processtable-perl \
+  libreadonly-perl \
+  libreadonly-xs-perl \
+  libroman-perl \
+  libsoap-lite-perl \
+  libspreadsheet-writeexcel-perl \
+  libsub-exporter-progressive-perl \
+  libsub-name-perl \
+  libtemplate-perl \
+  libterm-readkey-perl \
+  libterm-readline-gnu-perl \
+  libtest-requiresinternet-perl \
+  libtest-simple-perl \
+  libtie-ixhash-perl \
+  libtimedate-perl \
+  libtry-tiny-perl \
+  libuniversal-require-perl \
+  liburi-encode-perl \
+  libuuid-perl \
+  libuuid-tiny-perl \
+  libversion-perl \
+  libwww-perl \
+  libwww-robotrules-perl \
+  libxml-dom-perl \
+  libxml-libxml-perl \
+  libxml-libxslt-perl \
+  libxml-sax-perl \
+  libxml-simple-perl \
+  libxml-writer-perl \
+  libyaml-appconfig-perl \
+  libyaml-libyaml-perl \
+  libyaml-perl
+
+RUN apt-get install -y \
+  autoconf \
+  bison \
+  build-essential \
+  git \
+  libdevel-cover-perl \
+  libffi-dev \
+  libgdbm-dev \
+  libncurses5-dev \
+  libreadline6-dev \
+  libsqlite3-dev \
+  libssl-dev \
+  libyaml-dev \
+  netcat \
+  openssh-server \
+  unzip \
+  wget \
+  zip \
+  zlib1g-dev
+
+RUN cpan \
+  MARC::Record::MiJ \
+  OAuth::Lite
+
+RUN mkdir -p /htapps/babel/crms
+RUN wget -O /usr/local/bin/wait-for https://github.com/eficode/wait-for/releases/download/v2.2.3/wait-for; chmod +x /usr/local/bin/wait-for
+WORKDIR /htapps/babel/crms
+ENV CRMS_INSTANCE production
+

--- a/bin/duplicates.pl
+++ b/bin/duplicates.pl
@@ -7,6 +7,7 @@ use utf8;
 BEGIN {
   die "SDRROOT environment variable not set" unless defined $ENV{'SDRROOT'};
   use lib $ENV{'SDRROOT'} . '/crms/cgi';
+  use lib $ENV{'SDRROOT'} . '/crms/lib';
 }
 
 use Getopt::Long qw(:config no_ignore_case bundling);
@@ -90,6 +91,7 @@ my $crms = CRMS->new(
     verbose  => $verbose,
     instance => $instance
 );
+my $cron = CRMS::Cron->new(crms => $crms);
 
 
 sub Date1Field
@@ -338,12 +340,13 @@ print "Warning: $_\n" for @{$crms->GetErrors()};
 my $hashref = $crms->GetSdrDb()->{mysql_dbd_stats};
 printf "SDR Database OK reconnects: %d, bad reconnects: %d\n", $hashref->{'auto_reconnects_ok'}, $hashref->{'auto_reconnects_failed'} if $verbose;
 $txt .= "</body></html>\n\n" if $report eq 'html';
-if (@mails)
+my $recipients = $cron->recipients(@mails);
+if (scalar @$recipients)
 {
   use Encode;
   use Mail::Sendmail;
   my $bytes = encode('utf8', $txt);
-  my $to = join ',', @mails;
+  my $to = join ',', @$recipients;
   my %mail = ('from'         => $crms->GetSystemVar('sender_email'),
               'to'           => $to,
               'subject'      => $title,

--- a/bin/htreport.pl
+++ b/bin/htreport.pl
@@ -7,10 +7,13 @@ use utf8;
 BEGIN {
   die "SDRROOT environment variable not set" unless defined $ENV{'SDRROOT'};
   use lib $ENV{'SDRROOT'} . '/crms/cgi';
+  use lib $ENV{'SDRROOT'} . '/crms/lib';
 }
 
-use CRMS;
 use Getopt::Long;
+
+use CRMS;
+use CRMS::Cron;
 use Utilities;
 
 my $usage = <<END;
@@ -49,6 +52,7 @@ my $crms = CRMS->new(
     verbose  => $verbose,
     instance => $instance
 );
+my $cron = CRMS::Cron->new(crms => $crms);
 
 my ($start, $period);
 if ($year)
@@ -145,8 +149,8 @@ $rnote
 END
 
 $msg =~ s/__PERIOD__/$period/g;
-@mails = map { ($_ =~ m/@/)? $_:($_ . '@umich.edu'); } @mails;
-my $to = join ',', @mails;
+my $recipients = $cron->recipients(@mails);
+my $to = join ',', @$recipients;
 if ($noop)
 {
   print "No-op set; not sending e-mail to $to\n" if $verbose;

--- a/bin/mailer.pl
+++ b/bin/mailer.pl
@@ -7,12 +7,15 @@ use utf8;
 BEGIN {
   die "SDRROOT environment variable not set" unless defined $ENV{'SDRROOT'};
   use lib $ENV{'SDRROOT'} . '/crms/cgi';
+  use lib $ENV{'SDRROOT'} . '/crms/lib';
 }
 
-use CRMS;
-use Getopt::Long;
-use Utilities;
 use Encode;
+use Getopt::Long;
+
+use CRMS;
+use CRMS::Cron;
+use Utilities;
 
 my $usage = <<END;
 USAGE: $0 [-hpqtv] [-m USER [-m USER...]]
@@ -55,7 +58,10 @@ my $crms = CRMS->new(
     verbose  => $verbose,
     instance => $instance
 );
+my $cron = CRMS::Cron->new(crms => $crms);
+
 $crms->set('noop', 1) if $noop;
+my $default_recipients = $cron->recipients(@mails);
 
 my $sql = 'SELECT user,id,text,uuid,mailto,wait FROM mail WHERE sent IS NULL';
 my $ref = $crms->SelectAll($sql);
@@ -70,7 +76,7 @@ foreach my $row (@{$ref})
   my $wait = $row->[5];
   $id = undef if defined $id and $id eq '';
   my %mails;
-  $mails{$_} = 1 for @mails;
+  $mails{$_} = 1 for @$default_recipients;
   if (!$crms->IsDevArea())
   {
     $mails{$crms->GetSystemVar('experts_email')} = 1 unless $quiet;
@@ -166,15 +172,15 @@ END
   my @recipients = keys %mails;
   if (scalar @recipients)
   {
-    @recipients = map { ($_ =~ m/@/)? $_:($_ . '@umich.edu'); } @recipients;
-    $user .= '@umich.edu' unless $user =~ m/@/;
-    my $recipients = join ',', @recipients;
-    print "Sending to $recipients\n" if $verbose;
+    @recipients = map { $cron->expand_email($_); } @recipients;
+    $user = $cron->expand_email($user);
+    my $to = join ',', @recipients;
+    print "Sending to $to\n" if $verbose;
     use Encode;
     use Mail::Sendmail;
     my $bytes = encode('utf8', $msg);
     my %mail = ('from'         => $user,
-                'to'           => $recipients,
+                'to'           => $to,
                 'cc'           => $user,
                 'subject'      => $subj,
                 'content-type' => 'text/html; charset="UTF-8"',
@@ -182,7 +188,7 @@ END
                 );
     if ($noop)
     {
-      print "No-op set; not sending e-mail to $recipients\n" if $verbose;
+      print "No-op set; not sending e-mail to $to\n" if $verbose;
     }
     else
     {

--- a/docker/db/sql/001_crms_schema.sql
+++ b/docker/db/sql/001_crms_schema.sql
@@ -1247,6 +1247,30 @@ CREATE TABLE licensing (
   CONSTRAINT `manual_permissions_ibfk_attr` FOREIGN KEY (`attr`) REFERENCES `attributes` (`id`) ON UPDATE CASCADE,
   CONSTRAINT `manual_permissions_ibfk_reason` FOREIGN KEY (`reason`) REFERENCES `reasons` (`id`) ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+--
+-- Table structure for table `cron`
+--
+
+DROP TABLE IF EXISTS `cron`;
+CREATE TABLE cron (
+  `id` BIGINT AUTO_INCREMENT PRIMARY KEY NOT NULL,
+  `script` VARCHAR(64) UNIQUE NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+--
+-- Table structure for table `cron_recipients`
+--
+
+DROP TABLE IF EXISTS `cron_recipients`;
+CREATE TABLE cron_recipients (
+  `cron_id` BIGINT NOT NULL,
+  `email` VARCHAR(64) NOT NULL,
+  CONSTRAINT `cron_recipients_fk_cron_id` FOREIGN KEY (`cron_id`) REFERENCES `cron` (`id`) ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;

--- a/lib/CRMS/Cron.pm
+++ b/lib/CRMS/Cron.pm
@@ -1,0 +1,63 @@
+package CRMS::Cron;
+
+# Routines for handling cron and cron_recipients tables.
+# This class is mainly intended to be used from within
+# cron scripts located in bin/
+use strict;
+use warnings;
+use utf8;
+
+use File::Basename;
+
+my $DEFAULT_EMAIL_DOMAIN = 'umich.edu';
+my $DEFAULT_EMAIL_SUFFIX = '@' . $DEFAULT_EMAIL_DOMAIN;
+
+sub new {
+  my ($class, %args) = @_;
+  my $self = bless {}, $class;
+  # FIXME: once we have a standalone DB module this can go away.
+  my $crms = $args{crms};
+  die "CRMS::Cron module needs CRMS instance." unless defined $crms;
+  $self->{crms} = $crms;
+  $self->{script_name} = File::Basename::basename($0, '.pl');
+  return $self;
+}
+
+# Add default e-mail suffix to bare name.
+sub expand_email {
+  my $self  = shift;
+  my $email = shift;
+
+  $email .= $DEFAULT_EMAIL_SUFFIX unless $email =~ m/@/;
+  return $email;
+}
+
+# Input: array of e-mail recipients passed on the command line with -m flag.
+# Output: the same array, or the recipients in crms.cron_recipients if none.
+# All recipients are postprocessed to add @umich.edu if needed.
+sub recipients {
+  my $self  = shift;
+  my @mails = @_;
+
+  if (scalar @mails == 0) {
+    my $sql = 'SELECT id FROM cron WHERE script=?';
+    my $cron_id = $self->{crms}->SimpleSqlGet($sql, $self->script_name);
+    if (defined $cron_id) {
+      $sql = 'SELECT email FROM cron_recipients WHERE cron_id=?';
+      my $ref = $self->{crms}->SelectAll($sql, $cron_id);
+      push(@mails, $_->[0]) for @$ref;
+    }
+  }
+  @mails = map { $self->expand_email($_); } @mails;
+  return \@mails;
+}
+
+# Basename of the currently-running script.
+# Used for looking up cron.script column
+sub script_name {
+  my $self = shift;
+
+  return $self->{script_name};
+}
+
+1;

--- a/t/CRMS.t
+++ b/t/CRMS.t
@@ -5,16 +5,15 @@ use warnings;
 use utf8;
 BEGIN { unshift(@INC, $ENV{'SDRROOT'}. '/crms/cgi'); }
 
+use Data::Dumper;
 use Test::More;
 
 require_ok($ENV{'SDRROOT'}. '/crms/cgi/CRMS.pm');
 my $cgi = CGI->new();
 my $crms = CRMS->new('cgi' => $cgi, 'verbose' => 0);
 ok(defined $crms, 'CRMS object created');
-test_WriteRightsFile();
-done_testing();
 
-sub test_WriteRightsFile {
+subtest 'CRMS::WriteRightsFile' => sub {
   my $rights_data = join "\t", ('mdp.001', '1', '1', 'crms', 'null', '鬼塚英吉');
   $crms->WriteRightsFile($rights_data);
   my $path = $crms->get('export_path');
@@ -24,4 +23,6 @@ sub test_WriteRightsFile {
   my @fields = split "\t", $buffer;
   is($fields[5], '鬼塚英吉', "WriteRightsFile Unicode characters survive round trip");
   close $fh;
-}
+};
+
+done_testing();

--- a/t/Cron.t
+++ b/t/Cron.t
@@ -1,0 +1,73 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use utf8;
+
+use Data::Dumper;
+use Test::Exception;
+use Test::More;
+
+use lib "$ENV{SDRROOT}/crms/cgi";
+use lib "$ENV{SDRROOT}/crms/lib";
+
+use CRMS;
+
+require_ok($ENV{'SDRROOT'}. '/crms/lib/CRMS/Cron.pm');
+my $crms = CRMS->new;
+my $cron = CRMS::Cron->new('crms' => $crms);
+
+subtest 'CRMS::Cron::new' => sub {
+  subtest 'requires CRMS object' => sub {
+    throws_ok { CRMS::Cron->new; } qr/needs CRMS instance/i;
+  };
+};
+
+subtest 'CRMS::Cron::expand_email' => sub {
+  is($cron->expand_email('default'), 'default@umich.edu');
+  is($cron->expand_email('default@default.invalid'), 'default@default.invalid');
+};
+
+subtest 'CRMS::Cron::script_name' => sub {
+  is('Cron.t', $cron->script_name);
+};
+
+subtest 'CRMS::Cron::recipients' => sub {
+  subtest 'without DB config' => sub {
+    subtest 'with override' => sub {
+      my $list = ['user1', 'user2@default.invalid'];
+      my $expected_list = ['user1@umich.edu', 'user2@default.invalid'];
+      my $recipients = $cron->recipients(@$list);
+      is_deeply($recipients, $expected_list);
+    };
+
+    subtest 'without override' => sub {
+      my $recipients = $cron->recipients;
+      is_deeply($recipients, []);
+    };
+  };
+
+  subtest 'with DB config' => sub {
+    my $db_recipient = 'user3';
+    my $sql = 'INSERT INTO cron (script) VALUES (?)';
+    $crms->PrepareSubmitSql($sql, $cron->script_name);
+    $sql = 'INSERT INTO cron_recipients (cron_id,email)'.
+           ' VALUES ((SELECT MAX(id) FROM cron), ?)';
+    $crms->PrepareSubmitSql($sql, $db_recipient);
+    subtest 'with override' => sub {
+      my $list = ['user1', 'user2@default.invalid'];
+      my $expected_list = ['user1@umich.edu', 'user2@default.invalid'];
+      my $recipients = $cron->recipients(@$list);
+      is_deeply($recipients, $expected_list);
+    };
+
+    subtest 'without override' => sub {
+      my $recipients = $cron->recipients;
+      is_deeply($recipients, [$db_recipient . '@umich.edu']);
+    };
+    $crms->PrepareSubmitSql('DELETE FROM cron_recipients WHERE email=?', $db_recipient);
+    $crms->PrepareSubmitSql('DELETE FROM cron WHERE script=?', $cron->script_name);
+  };
+};
+
+done_testing();


### PR DESCRIPTION
DEV-511 Move CRMS cron jobs into Kubernetes
- Add GitHub actions.
- Add `crms.cron` and `crms.cron_recipients` tables to keep e-mail recipients out of cron params.
- Add `CRMS::Cron` module for use by most of the scripts in `bin/`.

Note: Reviewer(s) can probably ignore everything but `lib/CRMS/Cron.pm` and its tests.