### PR TITLE
GS-3742 put institutions file in correct place for wordpress

### DIFF
--- a/bin/institutions.pl
+++ b/bin/institutions.pl
@@ -30,11 +30,11 @@ download at https://www.hathitrust.org/institution_identifiers and for use by
 institutions for WAYFless login or login with Dex
 (https://tools.lib.umich.edu/confluence/display/HAT/OIDC+%3C-%3E+SAML+proxy+via+Dex)
 
-Data hosted on macc-ht-web-000 etc at /htapps/www/sites/www.hathitrust.org/files
+Data hosted on macc-ht-web-000 etc at config->hathitrust_files_directory
 
 -h       Print this help message.
 -m MAIL  Send note to MAIL. May be repeated for multiple recipients.
--n       No-op; do not send e-mail or move file into hathitrust.org filesystem.
+-n       No-op; do not send e-mail or move file into hathitrust_files_directory.
 -p       Run in production.
 -v       Emit verbose debugging information. May be repeated.
 END
@@ -78,20 +78,16 @@ $msg =~ s/__N__/$n/g;
 $msg =~ s/__OUTFILE_INSTID__/$outfile_instid/g;
 $msg =~ s/__OUTFILE_ENTITYID__/$outfile_entityid/g;
 
-if ($noop)
-{
+if ($noop) {
   $crms->set('noop', 1);
-  print "Noop set: not moving file to new location.\n";
-  $msg .= '<strong>Noop set: not moving file to new location.</strong>';
+  print "Noop set: not moving files to new location.\n";
+  $msg .= '<strong>Noop set: not moving files to new location.</strong>';
 }
-else
-{
+else {
   eval {
-    File::Copy::move $outfile_instid, '/htapps/www/files';
-    File::Copy::move $outfile_entityid, '/htapps/www/files';
+    $crms->MoveToHathitrustFiles($outfile_instid, $outfile_entityid);
   };
-  if ($@)
-  {
+  if ($@) {
     $msg .= '<strong>Error moving TSV file: $@</strong>';
   }
 }

--- a/bin/renewals.pl
+++ b/bin/renewals.pl
@@ -11,7 +11,6 @@ BEGIN {
 }
 
 use Encode;
-use File::Copy;
 use Getopt::Long;
 use JSON::XS;
 use Term::ANSIColor qw(:constants);
@@ -28,7 +27,7 @@ USAGE: $0 [-hnpqv] [-m MAIL [-m MAIL...]]
 Produces TSV file of HTID and renewal ID for Zephir download at
 https://www.hathitrust.org/files/CRMSRenewals.tsv
 
-Data hosted on macc-ht-web-000 etc at /htapps/www/sites/www.hathitrust.org/files
+Data hosted on macc-ht-web-000 etc at config->hathitrust_files_directory
 
 For each distinct HTID in historical reviews with one or more renewal IDs,
 gets all validated reviews with renewal IDs.
@@ -81,18 +80,15 @@ my $n = CheckStanford();
 $msg =~ s/__N__/$n/g;
 $msg =~ s/__OUTFILE__/$outfile/g;
 
-if ($noop)
-{
+if ($noop) {
   print "Noop set: not moving file to new location.\n";
   $msg .= '<strong>Noop set: not moving file to new location.</strong>';
 }
-else
-{
+else {
   eval {
-  File::Copy::move $outfile, '/htapps/www/sites/www.hathitrust.org/files';
+    $crms->MoveToHathitrustFiles($outfile);
   };
-  if ($@)
-  {
+  if ($@) {
     $msg .= '<strong>Error moving TSV file: $@</strong>';
   }
 }

--- a/cgi/CRMS.pm
+++ b/cgi/CRMS.pm
@@ -19,6 +19,7 @@ use Data::Dumper;
 use Date::Calc qw(:all);
 use DBI qw(:sql_types);
 use Encode;
+use File::Copy;
 use List::Util qw(min max);
 use LWP::UserAgent;
 use POSIX;
@@ -65,7 +66,7 @@ sub new
   return $self;
 }
 
-our $VERSION = '8.5.21';
+our $VERSION = '8.5.22';
 sub Version
 {
   return $VERSION;
@@ -289,6 +290,19 @@ sub MenuPath
     $newpath = $self->WebPath('cgi', $path);
   }
   return $newpath;
+}
+
+# Move one or more files into the hathitrust.org Wordpress files area
+# which is configured in config/config.yml.
+# Raises exception if File::Copy encounters a problem.
+sub MoveToHathitrustFiles {
+  my $self = shift;
+  my @files = @_;
+
+  my $dest = $self->GetSystemVar('hathitrust_files_directory');
+  foreach my $file (@files) {
+    File::Copy::move $file, $dest;
+  }
 }
 
 sub SetupLogFile

--- a/config/config.yml
+++ b/config/config.yml
@@ -42,5 +42,6 @@ experts_email: crms-experts@umich.edu
 mailing_list: ht-copyright-review@umich.edu,ht-commonwealth-review@umich.edu,ht-pubdate-review@umich.edu
 # Location in Production for writing .rights export files
 rights_export_directory: /htapps/babel/feed/var/rights
+hathitrust_files_directory: /htapps/www/files
 # Used by Jira.pm
 jira_prefix: https://hathitrust.atlassian.net

--- a/t/CRMS.t
+++ b/t/CRMS.t
@@ -6,12 +6,28 @@ use utf8;
 
 use lib "$ENV{SDRROOT}/crms/cgi";
 
+use File::Temp;
 use Test::More;
 
 require_ok($ENV{'SDRROOT'}. '/crms/cgi/CRMS.pm');
 my $cgi = CGI->new();
 my $crms = CRMS->new('cgi' => $cgi, 'verbose' => 0);
 ok(defined $crms, 'CRMS object created');
+
+subtest 'CRMS::MoveToHathitrustFiles' => sub {
+  my $tempdir = File::Temp::tempdir(CLEANUP => 1);
+  my $save_hathitrust_files_directory = $ENV{'CRMS_HATHITRUST_FILES_DIRECTORY'};
+  $ENV{'CRMS_HATHITRUST_FILES_DIRECTORY'} = $tempdir;
+  my $crms = CRMS->new('cgi' => $cgi);
+  my $src1 = $crms->FSPath('prep', 'test_1.txt');
+  my $src2 = $crms->FSPath('prep', 'test_2.txt');
+  `touch $src1`;
+  `touch $src2`;
+  $crms->MoveToHathitrustFiles($src1, $src2);
+  ok(-f "$tempdir/test_1.txt");
+  ok(-f "$tempdir/test_2.txt");
+  $ENV{'CRMS_HATHITRUST_FILES_DIRECTORY'} = $save_hathitrust_files_directory;
+};
 
 subtest 'CRMS::WriteRightsFile' => sub {
   my $rights_data = join "\t", ('mdp.001', '1', '1', 'crms', 'null', '鬼塚英吉');


### PR DESCRIPTION
- Follow-up to move hard-coded paths to config.
- DRY with common accessor `CRMS::MoveToHathitrustFiles`.
- Fixes remaining stale path in `bin/renewals.pl` not addressed by main GS-3742 fix.

Reviewer: just looking for a sanity check.