### PR TITLE
TTO-184 Rights predictor to 75 years for Canada anonymous works

### DIFF
--- a/cgi/CRMS.pm
+++ b/cgi/CRMS.pm
@@ -66,7 +66,7 @@ sub new
   return $self;
 }
 
-our $VERSION = '8.5.24';
+our $VERSION = '8.5.25';
 sub Version
 {
   return $VERSION;

--- a/lib/CRMS/RightsPredictor.pm
+++ b/lib/CRMS/RightsPredictor.pm
@@ -70,7 +70,7 @@ sub new {
 sub last_source_copyright {
   my $self              = shift;
   my $death_or_pub_date = shift || ''; # Reviewer-supplied
-  my $is_pub            = shift;
+  my $is_pub            = shift; # Treat $death_or_pub_date as pub date for corporate authors
   my $is_crown          = shift; # Crown copyright
   my $reference_year    = shift || POSIX::strftime("%Y", localtime); # The "current" year
 
@@ -218,7 +218,7 @@ sub predict_last_source_copyright {
 }
 
 sub australia_term {
-  my ($death_or_pub_date, $is_pub, $is_crown) = @_;
+  my ($death_or_pub_date, undef, $is_crown) = @_;
 
   return COMMONWEALTH_CROWN_COPYRIGHT_TERM if $is_crown;
   return 50 if $death_or_pub_date < 1955;
@@ -234,7 +234,7 @@ sub canada_term {
 }
 
 sub united_kingdom_term {
-  my ($death_or_pub_date, $is_pub, $is_crown) = @_;
+  my ($death_or_pub_date, undef, $is_crown) = @_;
 
   return ($is_crown) ? COMMONWEALTH_CROWN_COPYRIGHT_TERM : COMMONWEALTH_STANDARD_TERM;
 }

--- a/t/lib/CRMS/RightsPredictor.t
+++ b/t/lib/CRMS/RightsPredictor.t
@@ -24,7 +24,7 @@ subtest 'RightsPredictor::last_source_copyright' => sub {
     my $record = FakeMetadata::fake_record_with_008_and_leader($f008);
     my $rp = CRMS::RightsPredictor->new(record => $record);
     my $res = $rp->last_source_copyright(2000);
-    is($res->{last_source_copyright_year}, 2070);
+    is($res->{last_source_copyright_year}, 2070, 'UK baseline 70-year term');
   };
 
   subtest 'UK corporate work' => sub {
@@ -32,7 +32,7 @@ subtest 'RightsPredictor::last_source_copyright' => sub {
     my $record = FakeMetadata::fake_record_with_008_and_leader($f008);
     my $rp = CRMS::RightsPredictor->new(record => $record);
     my $res = $rp->last_source_copyright(2000, 1);
-    is($res->{last_source_copyright_year}, 2070);
+    is($res->{last_source_copyright_year}, 2070), 'UK corporate/anonymous 70-year term';
   };
 
   subtest 'UK crown' => sub {
@@ -40,7 +40,7 @@ subtest 'RightsPredictor::last_source_copyright' => sub {
     my $record = FakeMetadata::fake_record_with_008_and_leader($f008);
     my $rp = CRMS::RightsPredictor->new(record => $record);
     my $res = $rp->last_source_copyright(2000, 0, 1);
-    is($res->{last_source_copyright_year}, 2050);
+    is($res->{last_source_copyright_year}, 2050, 'UK crown copyright 50-year term');
   };
 
   subtest 'Canada pre-1972' => sub {
@@ -48,15 +48,23 @@ subtest 'RightsPredictor::last_source_copyright' => sub {
     my $record = FakeMetadata::fake_record_with_008_and_leader($f008);
     my $rp = CRMS::RightsPredictor->new(record => $record);
     my $res = $rp->last_source_copyright(1970);
-    is($res->{last_source_copyright_year}, 2020);
+    is($res->{last_source_copyright_year}, 2020, 'Canada has 50-year term when the effective date is prior to 1972');
   };
 
-  subtest 'Canada 1972' => sub {
+  subtest 'Canada 1972 author death date' => sub {
     my $f008 = '850423s1940    cn a          000 0 eng d';
     my $record = FakeMetadata::fake_record_with_008_and_leader($f008);
     my $rp = CRMS::RightsPredictor->new(record => $record);
     my $res = $rp->last_source_copyright(1972);
-    is($res->{last_source_copyright_year}, 2042);
+    is($res->{last_source_copyright_year}, 2042, 'Canada has 70-year term for author death dates on or after 1972');
+  };
+
+  subtest 'Canada 1972 corporate work' => sub {
+    my $f008 = '850423s1940    cn a          000 0 eng d';
+    my $record = FakeMetadata::fake_record_with_008_and_leader($f008);
+    my $rp = CRMS::RightsPredictor->new(record => $record);
+    my $res = $rp->last_source_copyright(1972, 1);
+    is($res->{last_source_copyright_year}, 2047, 'Canada has 75-year term for corporate/anonymous works published on or after 1972');
   };
 
   subtest 'Canada post-1972 author death date' => sub {
@@ -64,7 +72,7 @@ subtest 'RightsPredictor::last_source_copyright' => sub {
     my $record = FakeMetadata::fake_record_with_008_and_leader($f008);
     my $rp = CRMS::RightsPredictor->new(record => $record);
     my $res = $rp->last_source_copyright(2000);
-    is($res->{last_source_copyright_year}, 2070);
+    is($res->{last_source_copyright_year}, 2070, 'Canada has 70-year term for author death dates on or after 1972');
   };
 
   subtest 'Canada post-1972 corporate work' => sub {
@@ -72,15 +80,31 @@ subtest 'RightsPredictor::last_source_copyright' => sub {
     my $record = FakeMetadata::fake_record_with_008_and_leader($f008);
     my $rp = CRMS::RightsPredictor->new(record => $record);
     my $res = $rp->last_source_copyright(2000, 1);
-    is($res->{last_source_copyright_year}, 2075);
+    is($res->{last_source_copyright_year}, 2075, 'Canada has 75-year term for corporate/anonymous works published on or after 1972');
   };
 
-  subtest 'Canada crown' => sub {
+  subtest 'Canada pre-1972 crown' => sub {
+    my $f008 = '850423s1940    cn a          000 0 eng d';
+    my $record = FakeMetadata::fake_record_with_008_and_leader($f008);
+    my $rp = CRMS::RightsPredictor->new(record => $record);
+    my $res = $rp->last_source_copyright(1970, 0, 1);
+    is($res->{last_source_copyright_year}, 2020, 'Canada has 50-year term for crown copyright works regardless of effective date');
+  };
+
+  subtest 'Canada 1972 crown' => sub {
+    my $f008 = '850423s1940    cn a          000 0 eng d';
+    my $record = FakeMetadata::fake_record_with_008_and_leader($f008);
+    my $rp = CRMS::RightsPredictor->new(record => $record);
+    my $res = $rp->last_source_copyright(1972, 0, 1);
+    is($res->{last_source_copyright_year}, 2022, 'Canada has 50-year term for crown copyright works regardless of effective date');
+  };
+
+  subtest 'Canada post-1972 crown' => sub {
     my $f008 = '850423s1940    cn a          000 0 eng d';
     my $record = FakeMetadata::fake_record_with_008_and_leader($f008);
     my $rp = CRMS::RightsPredictor->new(record => $record);
     my $res = $rp->last_source_copyright(2000, 0, 1);
-    is($res->{last_source_copyright_year}, 2050);
+    is($res->{last_source_copyright_year}, 2050, 'Canada has 50-year term for crown copyright works regardless of effective date');
   };
 
   subtest 'Australia pre-1955' => sub {
@@ -88,7 +112,7 @@ subtest 'RightsPredictor::last_source_copyright' => sub {
     my $record = FakeMetadata::fake_record_with_008_and_leader($f008);
     my $rp = CRMS::RightsPredictor->new(record => $record);
     my $res = $rp->last_source_copyright(1950);
-    is($res->{last_source_copyright_year}, 2000);
+    is($res->{last_source_copyright_year}, 2000, 'Australia has 50-year term when the effective date is prior to 1955');
   };
 
   subtest 'Australia 1955' => sub {
@@ -96,7 +120,7 @@ subtest 'RightsPredictor::last_source_copyright' => sub {
     my $record = FakeMetadata::fake_record_with_008_and_leader($f008);
     my $rp = CRMS::RightsPredictor->new(record => $record);
     my $res = $rp->last_source_copyright(1955);
-    is($res->{last_source_copyright_year}, 2025);
+    is($res->{last_source_copyright_year}, 2025, 'Australia has 70-year term when the effective date is on or after 1955');
   };
 
   subtest 'Australia post-1955' => sub {
@@ -104,15 +128,31 @@ subtest 'RightsPredictor::last_source_copyright' => sub {
     my $record = FakeMetadata::fake_record_with_008_and_leader($f008);
     my $rp = CRMS::RightsPredictor->new(record => $record);
     my $res = $rp->last_source_copyright(2000);
-    is($res->{last_source_copyright_year}, 2070);
+    is($res->{last_source_copyright_year}, 2070, 'Australia has 70-year term when the effective date is on or after 1955');
   };
 
-  subtest 'Australia crown' => sub {
+  subtest 'Australia pre-1955 crown' => sub {
+    my $f008 = '850423s1940    at a          000 0 eng d';
+    my $record = FakeMetadata::fake_record_with_008_and_leader($f008);
+    my $rp = CRMS::RightsPredictor->new(record => $record);
+    my $res = $rp->last_source_copyright(1940, 0, 1);
+    is($res->{last_source_copyright_year}, 1990, 'Australia has 50-year term for crown copyright works regardless of effective date');
+  };
+
+  subtest 'Australia 1955 crown' => sub {
+    my $f008 = '850423s1940    at a          000 0 eng d';
+    my $record = FakeMetadata::fake_record_with_008_and_leader($f008);
+    my $rp = CRMS::RightsPredictor->new(record => $record);
+    my $res = $rp->last_source_copyright(1955, 0, 1);
+    is($res->{last_source_copyright_year}, 2005, 'Australia has 50-year term for crown copyright works regardless of effective date');
+  };
+
+  subtest 'Australia post-1955 crown' => sub {
     my $f008 = '850423s1940    at a          000 0 eng d';
     my $record = FakeMetadata::fake_record_with_008_and_leader($f008);
     my $rp = CRMS::RightsPredictor->new(record => $record);
     my $res = $rp->last_source_copyright(2000, 0, 1);
-    is($res->{last_source_copyright_year}, 2050);
+    is($res->{last_source_copyright_year}, 2050, 'Australia has 50-year term for crown copyright works regardless of effective date');
   };
 
   subtest 'Unknown country' => sub {
@@ -120,7 +160,7 @@ subtest 'RightsPredictor::last_source_copyright' => sub {
     my $record = FakeMetadata::fake_record_with_008_and_leader($f008);
     my $rp = CRMS::RightsPredictor->new(record => $record);
     my $res = $rp->last_source_copyright(2000);
-    ok(!defined $res->{last_source_copyright_year});
+    ok(!defined $res->{last_source_copyright_year}, 'Last source copyright year cannot be defined for unknown country');
     ok(join(', ', @{$res->{desc}}) =~ m/country/i);
   };
 
@@ -131,7 +171,7 @@ subtest 'RightsPredictor::last_source_copyright' => sub {
     my @bogus_years = (undef, 'abcd', '', 12345);
     foreach my $year (@bogus_years) {
       my $res = $rp->last_source_copyright($year);
-      ok(!defined $res->{last_source_copyright_year});
+      ok(!defined $res->{last_source_copyright_year}, 'Last source copyright year cannot be defined for unknown country');
       ok(join(', ', @{$res->{desc}}) =~ m/unsupported/i);
     }
   };
@@ -143,8 +183,8 @@ subtest 'RightsPredictor::last_source_copyright' => sub {
     my @ok_years = ('-1', '-0', '0000', 999999);
     foreach my $year (@ok_years) {
       my $res = $rp->last_source_copyright(2000);
-      ok(defined $res->{last_source_copyright_year});
-      ok(join(', ', $res->{desc}) !~ m/unsupported/i);
+      ok(defined $res->{last_source_copyright_year}, "Last source copyright year is defined even if the input is $year");
+      ok(join(', ', $res->{desc}) !~ m/unsupported/i, "No 'unsupported date format' error for $year");
     }
   };
 };
@@ -259,4 +299,3 @@ subtest 'RightsPredictor::rights' => sub {
 };
 
 done_testing();
-

--- a/t/lib/CRMS/RightsPredictor.t
+++ b/t/lib/CRMS/RightsPredictor.t
@@ -31,7 +31,7 @@ subtest 'RightsPredictor::last_source_copyright' => sub {
     my $f008 = '850423s1940    uk a          000 0 eng d';
     my $record = FakeMetadata::fake_record_with_008_and_leader($f008);
     my $rp = CRMS::RightsPredictor->new(record => $record);
-    my $res = $rp->last_source_copyright(2000, 1);
+    my $res = $rp->last_source_copyright(2000, 0, 1);
     is($res->{last_source_copyright_year}, 2050);
   };
 
@@ -51,7 +51,7 @@ subtest 'RightsPredictor::last_source_copyright' => sub {
     is($res->{last_source_copyright_year}, 2042);
   };
 
-  subtest 'Canada post-1972' => sub {
+  subtest 'Canada post-1972 author death date' => sub {
     my $f008 = '850423s1940    cn a          000 0 eng d';
     my $record = FakeMetadata::fake_record_with_008_and_leader($f008);
     my $rp = CRMS::RightsPredictor->new(record => $record);
@@ -59,11 +59,19 @@ subtest 'RightsPredictor::last_source_copyright' => sub {
     is($res->{last_source_copyright_year}, 2070);
   };
 
-  subtest 'Canada crown' => sub {
+  subtest 'Canada post-1972 corporate work' => sub {
     my $f008 = '850423s1940    cn a          000 0 eng d';
     my $record = FakeMetadata::fake_record_with_008_and_leader($f008);
     my $rp = CRMS::RightsPredictor->new(record => $record);
     my $res = $rp->last_source_copyright(2000, 1);
+    is($res->{last_source_copyright_year}, 2075);
+  };
+
+  subtest 'Canada crown' => sub {
+    my $f008 = '850423s1940    cn a          000 0 eng d';
+    my $record = FakeMetadata::fake_record_with_008_and_leader($f008);
+    my $rp = CRMS::RightsPredictor->new(record => $record);
+    my $res = $rp->last_source_copyright(2000, 0, 1);
     is($res->{last_source_copyright_year}, 2050);
   };
 
@@ -95,7 +103,7 @@ subtest 'RightsPredictor::last_source_copyright' => sub {
     my $f008 = '850423s1940    at a          000 0 eng d';
     my $record = FakeMetadata::fake_record_with_008_and_leader($f008);
     my $rp = CRMS::RightsPredictor->new(record => $record);
-    my $res = $rp->last_source_copyright(2000, 1);
+    my $res = $rp->last_source_copyright(2000, 0, 1);
     is($res->{last_source_copyright_year}, 2050);
   };
 

--- a/t/lib/CRMS/RightsPredictor.t
+++ b/t/lib/CRMS/RightsPredictor.t
@@ -27,6 +27,14 @@ subtest 'RightsPredictor::last_source_copyright' => sub {
     is($res->{last_source_copyright_year}, 2070);
   };
 
+  subtest 'UK corporate work' => sub {
+    my $f008 = '850423s1940    uk a          000 0 eng d';
+    my $record = FakeMetadata::fake_record_with_008_and_leader($f008);
+    my $rp = CRMS::RightsPredictor->new(record => $record);
+    my $res = $rp->last_source_copyright(2000, 1);
+    is($res->{last_source_copyright_year}, 2070);
+  };
+
   subtest 'UK crown' => sub {
     my $f008 = '850423s1940    uk a          000 0 eng d';
     my $record = FakeMetadata::fake_record_with_008_and_leader($f008);


### PR DESCRIPTION
- Rights predictor for Canada is now sensitive to the is_pub/anonymous/corporate status of a work
  - Use a new constant `CANADA_CORPORATE_TERM` set to 75 years
  - Pass `is_pub` flag to `last_source_copyright` method
  - Pass along the `is_pub` flag to all per-country rights predictors
  - Update tests with a separate author death date vs anonymous/pub date example for Canada
    - Add a couple tests for other countries to make sure the change only applies to Canada
 - The overall complexity of `RightsPredictor` will be addressed in DEV-1057 with a bit of a refactor.