### PR TITLE
Fix issue with Commonwealth date type 'r' with unknown original date

### DIFF
--- a/cgi/CRMS.pm
+++ b/cgi/CRMS.pm
@@ -66,7 +66,7 @@ sub new
   return $self;
 }
 
-our $VERSION = '8.6';
+our $VERSION = '8.6.1';
 sub Version
 {
   return $VERSION;

--- a/cgi/partial/ADDForm.tt
+++ b/cgi/partial/ADDForm.tt
@@ -37,9 +37,9 @@
       </td>
     </tr>
     <!-- ACTUAL PUB DATE -->
-    <!-- Only visible when pub is unchecked and pub date is a range -->
+    <!-- Only visible when pub is unchecked and pub date is a range or unknown -->
     [% display = "table-row" %]
-    [% IF u_pub || data.bibdata.extracted_dates.size != 2 %]
+    [% IF u_pub || data.bibdata.extracted_dates.size == 1 %]
       [% display = "none" %]
     [% END %]
     <tr id="actual-pub-date-row" style="display:[% display %];">
@@ -293,7 +293,7 @@ function toggleADD() {
       addField.value = actualField.value;
     }
   } else {
-    if (gReviewData.bibdata.extracted_dates.length > 1) {
+    if (gReviewData.bibdata.extracted_dates.size != 1) {
       actualPubDateRow.style.display = "table-row";
     }
   }

--- a/cgi/partial/bibdata_commonwealth.tt
+++ b/cgi/partial/bibdata_commonwealth.tt
@@ -5,8 +5,8 @@
       <tr>
         <td><strong>Pub Date:</strong>
           <span id="pub-date-span"
-            [% IF data.bibdata.extracted_dates.size > 1 %]class="red"[% END %]>
-            [% data.bibdata.display_date %]
+            [% IF data.bibdata.extracted_dates.size != 1 %]class="red"[% END %]>
+            [% data.bibdata.display_date || '(unknown)' %]
           </span>
         </td>
       </tr>


### PR DESCRIPTION
- Add "(unknown)" scenario to metadata display
- Expand logic to use "not one" instead of "equals two" as criterion for actual pub date entry.