### PR TITLE
TTO-231 multivalue env email

### DIFF
--- a/cgi/CRMS.pm
+++ b/cgi/CRMS.pm
@@ -83,8 +83,7 @@ sub SetupUser
 
   my $note = '';
   my $sdr_dbh = $self->get('ht_repository');
-  if (!defined $sdr_dbh)
-  {
+  if (!defined $sdr_dbh) {
     $sdr_dbh = $self->ConnectToSdrDb('ht_repository');
     $self->set('ht_repository', $sdr_dbh) if defined $sdr_dbh;
   }
@@ -95,64 +94,53 @@ sub SetupUser
   my $candidate = $ENV{'REMOTE_USER'};
   $candidate = lc $candidate if defined $candidate;
   $note .= sprintf "ENV{REMOTE_USER}=%s\n", (defined $candidate)? $candidate:'<undef>';
-  if ($candidate)
-  {
-    my $candidate2;
+  if ($candidate) {
+    my $ht_users_email;
     my $ref = $sdr_dbh->selectall_arrayref($htsql, undef, $candidate);
-    if ($ref && scalar @{$ref})
-    {
+    if ($ref && scalar @{$ref}) {
       $ht_user = $candidate;
       $note .= "Set ht_user=$ht_user\n";
-      $candidate2 = $ref->[0]->[0];
+      $ht_users_email = $ref->[0]->[0];
     }
-    if ($self->SimpleSqlGet($usersql, $candidate))
-    {
+    if ($self->SimpleSqlGet($usersql, $candidate)) {
       $crms_user = $candidate;
       $note .= "Set crms_user=$crms_user from lc ENV{REMOTE_USER}\n";
     }
-    if (!$crms_user && $self->SimpleSqlGet($usersql, $candidate2))
-    {
-      $crms_user = $candidate2;
+    if (!$crms_user && $self->SimpleSqlGet($usersql, $ht_users_email)) {
+      $crms_user = $ht_users_email;
       $note .= "Set crms_user=$crms_user from ht_users.email\n";
     }
   }
-  if (!$crms_user || !$ht_user)
-  {
+  if (!$crms_user || !$ht_user) {
     $note .= sprintf "ENV{email}=%s\n", (defined $ENV{email}) ? $ENV{email} : '<undef>';
     foreach my $candidate ($self->extract_env_email) {
-      my $candidate2;
+      my $ht_users_email;
       my $ref = $sdr_dbh->selectall_arrayref($htsql, undef, $candidate);
-      if ($ref && scalar @{$ref} && !$ht_user)
-      {
+      if ($ref && scalar @$ref && !$ht_user) {
         $ht_user = $candidate;
         $note .= "Set ht_user=$ht_user\n";
-        $candidate2 = $ref->[0]->[0];
+        $ht_users_email = $ref->[0]->[0];
       }
-      if ($self->SimpleSqlGet($usersql, $candidate) && !$crms_user)
-      {
+      if ($self->SimpleSqlGet($usersql, $candidate) && !$crms_user) {
         $crms_user = $candidate;
         $note .= "Set crms_user=$crms_user from ENV{email} candidate $candidate\n";
       }
-      if (!$crms_user && $self->SimpleSqlGet($usersql, $candidate2) && !$crms_user)
-      {
-        $crms_user = $candidate2;
+      if (!$crms_user && $self->SimpleSqlGet($usersql, $ht_users_email)) {
+        $crms_user = $ht_users_email;
         $note .= "Set crms_user=$crms_user from ht_users.email\n";
       }
       # No need to iterate further if we have a match in both crms.users and ht.ht_users
       last if $ht_user && $crms_user;
     }
   }
-  if ($ht_user)
-  {
-    if ($self->NeedStepUpAuth($ht_user))
-    {
+  if ($ht_user) {
+    if ($self->NeedStepUpAuth($ht_user)) {
       $note .= "HT user $ht_user step-up auth required.\n";
       $self->set('stepup', 1);
     }
     $self->set('ht_user', $ht_user);
   }
-  if ($crms_user)
-  {
+  if ($crms_user) {
     $note .= "Setting CRMS user to $crms_user.\n";
     $self->set('remote_user', $crms_user);
     my $alias = $self->GetAlias($crms_user);

--- a/cgi/CRMS.pm
+++ b/cgi/CRMS.pm
@@ -165,6 +165,27 @@ sub SetupUser
   return $crms_user;
 }
 
+# Extract potentially multiple values of ENV{email} as an array ref.
+# We have seen multiple (duplicate) values of email separated by semicolons
+# coming from Shib.
+# Values are downcased, unique, nonempty strings with any "@umich.edu" stripped.
+sub extract_env_email {
+  my $self = shift;
+
+  my $emails = [];
+  if (defined $ENV{email}) {
+    my %seen;
+    foreach my $email (split(';', lc $ENV{email})) {
+      $email =~ s/\@umich.edu//;
+      if (length $email && !$seen{$email}) {
+        push @$emails, $email;
+        $seen{$email} = 1;
+      }
+    }
+  }
+  return $emails;
+}
+
 # Construct redirect URL based on template
 # replace __HOST__ with $ENV{SERVER_NAME}
 # replace __TARGET__ with something like CGI::self_url($cgi)

--- a/cgi/CRMS.pm
+++ b/cgi/CRMS.pm
@@ -113,7 +113,7 @@ sub SetupUser
   }
   if (!$crms_user || !$ht_user) {
     $note .= sprintf "ENV{email}=%s\n", (defined $ENV{email}) ? $ENV{email} : '<undef>';
-    foreach my $candidate ($self->extract_env_email) {
+    foreach my $candidate (@{$self->extract_env_email}) {
       my $ht_users_email;
       my $ref = $sdr_dbh->selectall_arrayref($htsql, undef, $candidate);
       if ($ref && scalar @$ref && !$ht_user) {

--- a/cgi/CRMS.pm
+++ b/cgi/CRMS.pm
@@ -156,12 +156,13 @@ sub SetupUser
 # coming from Shib.
 # Values are downcased, unique, nonempty strings with any "@umich.edu" stripped.
 sub extract_env_email {
-  my $self = shift;
+  my $self      = shift;
+  my $env_email = shift || $ENV{email};
 
   my $emails = [];
-  if (defined $ENV{email}) {
+  if (defined $env_email) {
     my %seen;
-    foreach my $email (split(';', lc $ENV{email})) {
+    foreach my $email (split(';', lc $env_email)) {
       $email =~ s/\@umich.edu//;
       if (length $email && !$seen{$email}) {
         push @$emails, $email;

--- a/t/CRMS.t
+++ b/t/CRMS.t
@@ -19,23 +19,25 @@ subtest '#Version' => sub {
 };
 
 subtest '#extract_env_email' => sub {
+  my $tests = [
+    # Each is [INPUT, OUTPUT, TEST_COMMENT]
+    [undef, [], 'empty array if no email defined'],
+    ['', [], 'empty array if empty string'],
+    ['someone@somewhere.edu', ['someone@somewhere.edu'], 'extracts single value'],
+    ['someone@somewhere.edu;someone_else@somewhere.edu', ['someone@somewhere.edu', 'someone_else@somewhere.edu'], 'extracts multiple values'],
+    [';someone@somewhere.edu', ['someone@somewhere.edu'], 'ignores leading semicolon'],
+    ['someone@somewhere.edu;', ['someone@somewhere.edu'], 'ignores trailing semicolon'],
+    ['someone@umich.edu', ['someone'], 'strips @umich.edu'],
+    ['someone@somewhere.edu;someone@somewhere.edu', ['someone@somewhere.edu'], 'merges duplicates'],
+    ['SOMEONE@SOMEWHERE.EDU', ['someone@somewhere.edu'], 'downcases']
+  ];
   my $save_email = $ENV{email};
   delete $ENV{email};
-  is_deeply($crms->extract_env_email, [], 'empty array if no ENV{email} defined');
+  foreach my $test (@$tests) {
+    is_deeply($crms->extract_env_email($test->[0]), $test->[1], $test->[2]);
+  }
   $ENV{email} = 'someone@somewhere.edu';
-  is_deeply($crms->extract_env_email, ['someone@somewhere.edu'], 'extracts single value');
-  $ENV{email} = 'someone@somewhere.edu;someone_else@somewhere.edu';
-  is_deeply($crms->extract_env_email, ['someone@somewhere.edu', 'someone_else@somewhere.edu'], 'extracts multiple values');
-  $ENV{email} = ';someone@somewhere.edu';
-  is_deeply($crms->extract_env_email, ['someone@somewhere.edu'], 'ignores leading semicolon');
-  $ENV{email} = 'someone@somewhere.edu;';
-  is_deeply($crms->extract_env_email, ['someone@somewhere.edu'], 'ignores trailing semicolon');
-  $ENV{email} = 'someone@umich.edu';
-  is_deeply($crms->extract_env_email, ['someone'], 'strips @umich.edu');
-  $ENV{email} = 'someone@somewhere.edu;someone@somewhere.edu';
-  is_deeply($crms->extract_env_email, ['someone@somewhere.edu'], 'merges duplicates');
-  $ENV{email} = 'SOMEONE@SOMEWHERE.EDU';
-  is_deeply($crms->extract_env_email, ['someone@somewhere.edu'], 'downcases');
+  is_deeply($crms->extract_env_email, ['someone@somewhere.edu'], 'uses ENV{email} if no parameter');
   $ENV{email} = $save_email;
 };
 

--- a/t/CRMS.t
+++ b/t/CRMS.t
@@ -18,6 +18,27 @@ subtest '#Version' => sub {
   ok($crms->Version);
 };
 
+subtest '#extract_env_email' => sub {
+  my $save_email = $ENV{email};
+  delete $ENV{email};
+  is_deeply($crms->extract_env_email, [], 'empty array if no ENV{email} defined');
+  $ENV{email} = 'someone@somewhere.edu';
+  is_deeply($crms->extract_env_email, ['someone@somewhere.edu'], 'extracts single value');
+  $ENV{email} = 'someone@somewhere.edu;someone_else@somewhere.edu';
+  is_deeply($crms->extract_env_email, ['someone@somewhere.edu', 'someone_else@somewhere.edu'], 'extracts multiple values');
+  $ENV{email} = ';someone@somewhere.edu';
+  is_deeply($crms->extract_env_email, ['someone@somewhere.edu'], 'ignores leading semicolon');
+  $ENV{email} = 'someone@somewhere.edu;';
+  is_deeply($crms->extract_env_email, ['someone@somewhere.edu'], 'ignores trailing semicolon');
+  $ENV{email} = 'someone@umich.edu';
+  is_deeply($crms->extract_env_email, ['someone'], 'strips @umich.edu');
+  $ENV{email} = 'someone@somewhere.edu;someone@somewhere.edu';
+  is_deeply($crms->extract_env_email, ['someone@somewhere.edu'], 'merges duplicates');
+  $ENV{email} = 'SOMEONE@SOMEWHERE.EDU';
+  is_deeply($crms->extract_env_email, ['someone@somewhere.edu'], 'downcases');
+  $ENV{email} = $save_email;
+};
+
 subtest 'CRMS::MoveToHathitrustFiles' => sub {
   my $tempdir = File::Temp::tempdir(CLEANUP => 1);
   my $save_hathitrust_files_directory = $ENV{'CRMS_HATHITRUST_FILES_DIRECTORY'};


### PR DESCRIPTION
This is in response to an unusual behavior noted with University of Kentucky's use of Shib when their users are authenticated for CRMS access. CRMS determines who is who (matching its users against both the `crms.users` table as well as `ht.ht_users`) by consulting `$ENV{REMOTE_USER}` and falling back to `$ENV{email}`. `uky.edu` was providing `email` values like `user@uky.edu;user@uky.edu` possibly due to some misconfiguration. I agreed with A&E (after a long slack thread referenced in the ticket) that we should just try to accommodate multiple values as we would fields like `eppn`. This we have an additional loop over possible multiple values of email where previously we have been assuming it held a single value.

The commits:
  - A testable utility routine that parses the `ENV{email}` value and applies needed transformations.
  - Modify the caller subroutine `SetupUser` to use the new utility. The is the meat of the branch.
  - Tidy `SetupUser`.
  - Fix deferencing bug not detected prior to integration test under dev-2

Reviewer:
  - Would like a scan of the modified `SetupUser` in the area of the `ENV{email}` check -- there is some cleanup work to be done where the code unnecessarily refers to `ht_repository` and that is the subject of a lower-priority GitHub issue to be addressed later.
  - Would like to have a quick review of the added tests. Should `extract_env_email` take an optional string parameter defaulting to `ENV{email}` so we don't have to set and restore `ENV` in the tests?