### PR TITLE
TTO-276 Revise queueing order in CRMS

### DIFF
--- a/cgi/CRMS.pm
+++ b/cgi/CRMS.pm
@@ -1461,8 +1461,7 @@ sub LoadQueueForProject {
     my $record = $self->GetMetadata($sysid);
     $sql = 'SELECT c.id FROM candidates c'.
            ' INNER JOIN bibdata b ON c.id=b.id'.
-           ' WHERE c.project=? AND b.sysid=?'.
-           ' ORDER BY ' . join(',', @orders);
+           ' WHERE c.project=? AND b.sysid=?';
     my $ref2 = $self->SelectAll($sql, $project, $sysid);
     foreach my $row2 (@$ref2) {
       my $id = $row2->[0];

--- a/cgi/CRMS.pm
+++ b/cgi/CRMS.pm
@@ -1436,11 +1436,15 @@ sub LoadQueueForProject {
   my $project_name = $self->GetProjectRef($project)->name;
   my $sql = 'SELECT COUNT(*) FROM queue WHERE project=?';
   my $queueSize = $self->SimpleSqlGet($sql, $project);
-  my $targetQueueSize = $self->GetProjectRef($project)->queue_size();
+  my $project_ref = $self->GetProjectRef($project);
+  my $targetQueueSize = $project_ref->queue_size();
   my $needed = $targetQueueSize - $queueSize;
   $self->ReportMsg("Project $project_name: $queueSize volumes -- need $needed");
   return if $needed <= 0;
   my $count = 0;
+  my @orders = ('c.time DESC');
+  my $project_order = $project_ref->queue_order;
+  unshift @orders, $project_order if defined $project_order;
   $sql = 'SELECT DISTINCT b.sysid FROM bibdata b'.
          ' INNER JOIN candidates c ON b.id = c.id'.
          ' WHERE b.id NOT IN (SELECT DISTINCT id FROM inherit)'.
@@ -1448,7 +1452,7 @@ sub LoadQueueForProject {
          ' AND b.id NOT IN (SELECT DISTINCT id FROM reviews)'.
          ' AND b.id NOT IN (SELECT DISTINCT id FROM historicalreviews)'.
          ' AND c.time<=DATE_SUB(NOW(), INTERVAL 1 WEEK) AND c.project=?'.
-         ' ORDER BY c.time DESC';
+         ' ORDER BY ' . join(',', @orders);
   my $ref = $self->SelectAll($sql, $project);
   my $potential = scalar @$ref;
   $self->ReportMsg("$potential qualifying catalog records for project $project queue");
@@ -1458,7 +1462,7 @@ sub LoadQueueForProject {
     $sql = 'SELECT c.id FROM candidates c'.
            ' INNER JOIN bibdata b ON c.id=b.id'.
            ' WHERE c.project=? AND b.sysid=?'.
-           ' ORDER BY c.time ASC';
+           ' ORDER BY ' . join(',', @orders);
     my $ref2 = $self->SelectAll($sql, $project, $sysid);
     foreach my $row2 (@$ref2) {
       my $id = $row2->[0];

--- a/cgi/Project.pm
+++ b/cgi/Project.pm
@@ -10,9 +10,11 @@ sub new
   $self->{$_} = $args{$_} for keys %args;
   my $id = $args{'id'};
   die "No CRMS object passed to project" unless $args{'crms'};
-  my $sql = 'SELECT * FROM projects WHERE id=?';
-  my $ref = $self->{'crms'}->get('dbh')->selectall_hashref($sql, 'id', undef, $id);
-  $self->{$_} = $ref->{$id}->{$_} for keys %{$ref->{$id}};
+  if (defined $id) {
+    my $sql = 'SELECT * FROM projects WHERE id=?';
+    my $ref = $self->{'crms'}->get('dbh')->selectall_hashref($sql, 'id', undef, $id);
+    $self->{$_} = $ref->{$id}->{$_} for keys %{$ref->{$id}};
+  }
   return $self;
 }
 
@@ -93,6 +95,16 @@ sub EvaluateCandidacy
 }
 
 # ========== REVIEW INTERFACE ========== #
+# Called by CRMS::LoadQueueForProject to prioritize candidates for the queue.
+# Return undef for no additional order (the default), or
+# a column name in bibdata (b.*) or candidates (c.*).
+# Example: 'b.author DESC'
+sub queue_order {
+  my $self = shift;
+
+  return;
+}
+
 # Called by CRMS::GetNextItemForReview to order volumes.
 # Return undef for no additional order (the default), or
 # a column name in bibdata (b.*) or the queue (q.*).

--- a/cgi/Project.pm
+++ b/cgi/Project.pm
@@ -99,22 +99,14 @@ sub EvaluateCandidacy
 # Return undef for no additional order (the default), or
 # a column name in bibdata (b.*) or candidates (c.*).
 # Example: 'b.author DESC'
-sub queue_order {
-  my $self = shift;
-
-  return;
-}
+sub queue_order { }
 
 # Called by CRMS::GetNextItemForReview to order volumes.
 # Return undef for no additional order (the default), or
 # a column name in bibdata (b.*) or the queue (q.*).
 # Example: 'b.author DESC'
-sub PresentationOrder
-{
-  my $self = shift;
+sub PresentationOrder { }
 
-  return;
-}
 
 sub ReviewPartials
 {

--- a/cgi/Project/Core.pm
+++ b/cgi/Project/Core.pm
@@ -120,6 +120,16 @@ sub HasCCLicense
 }
 
 # ========== REVIEW ========== #
+sub queue_order {
+  # Add mdp namespace to queue ahead of everything else.
+  return 'IF("mdp"=LEFT(c.id,LOCATE(".",c.id)-1),1,0) DESC';
+}
+
+sub PresentationOrder {
+  # Present mdp namespace ahead of everything else.
+  return 'IF("mdp"=LEFT(q.id,LOCATE(".",q.id)-1),1,0) DESC';
+}
+
 sub ReviewPartials
 {
   return ['top', 'bibdata', 'authorities',

--- a/t/Project.t
+++ b/t/Project.t
@@ -26,5 +26,9 @@ subtest '#queue_order' => sub {
   is($project->queue_order, undef, 'default project has no queue_order');
 };
 
+subtest '#PresentationOrder' => sub {
+  is($project->PresentationOrder, undef, 'default project has no PresentationOrder');
+};
+
 done_testing();
 

--- a/t/Project.t
+++ b/t/Project.t
@@ -6,6 +6,8 @@ BEGIN { unshift(@INC, $ENV{'SDRROOT'}. '/crms/cgi'); }
 
 use Test::More;
 
+use CRMS;
+
 my $dir = $ENV{'SDRROOT'}. '/crms/cgi/Project';
 opendir(DIR, $dir) or die "Can't open $dir\n";
 my @files = readdir(DIR);
@@ -16,6 +18,13 @@ foreach my $file (sort @files)
   my $path = "$dir/$file";
   require_ok($path);
 }
+
+my $crms = CRMS->new;
+
+my $project = Project->new(crms => $crms);
+subtest '#queue_order' => sub {
+  is($project->queue_order, undef, 'default project has no queue_order');
+};
 
 done_testing();
 

--- a/t/Project/Core.t
+++ b/t/Project/Core.t
@@ -1,0 +1,35 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use utf8;
+
+use CGI;
+use Data::Dumper;
+use Test::More;
+
+use lib $ENV{'SDRROOT'} . '/crms/cgi';
+use lib $ENV{'SDRROOT'} . '/crms/t/support';
+use CRMS;
+use FakeMetadata;
+
+require_ok($ENV{'SDRROOT'}. '/crms/cgi/Project/Core.pm');
+
+my $crms = CRMS->new();
+# TODO: Project::for_name would be a much nicer way to do this.
+my $sql = 'SELECT id FROM projects WHERE name="Core"';
+my $project_id = $crms->SimpleSqlGet($sql);
+my $project = Core->new(crms => $crms, id => $project_id);
+ok(defined $project);
+
+subtest '#queue_order' => sub {
+  ok(defined $project->queue_order, 'Core project defines a queue_order');
+};
+
+subtest '#PresentationOrder' => sub {
+  ok(defined $project->PresentationOrder, 'Core project defines a PresentationOrder');
+};
+
+done_testing();
+
+


### PR DESCRIPTION
TL;DR for reviewer: a quick scan suffices, read on if fascinated with minutiae.

Note to reviewer: this has been tested on dev-2. This is a somewhat inconsequential tweak to the runtime behavior of the system. Basically we want to promote "mdp" volumes to the front of the queue and the front of the candidates.  `PresentationOrder` is an existing mechanism (note camel case) and `queue_order` is the new method (note snake case) using almost the same mechanism, just applied to a different query. (The mechanism is embarrassingly clunky but I don't know how else to do it: basically we allow a Project to respond with its own `ORDER BY` clause that gets plugged into the caller's query.)

I have an issue (#195) to change the return values of these subclass methods. Out of scope for this ticket.

- Add a custom `PresentationOrder` to the Core project to prioritize mdp namespace.
- Add a new `Project#queue_order` used the same way as `PresentationOrder` except:
  - It applies to the list of candidates being considered for addition to the Queue.
  - Like `PresentationOrder` the custom `ORDER BY` becomes the first order clause.
  - And the default behavior is to return `undef`.