### PR TITLE
ETT-400 Change Credential Handling

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,12 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check out including private submodules
+      - name: Check out including submodules
         uses: actions/checkout@v4
         with:
-          # This should be a PAT that has read access to the private submodules
-          # for this repository
-          token: ${{ secrets.ACCESS_TOKEN }}
           submodules: true
 
       - name: Build docker image

--- a/cgi/CRMS.pm
+++ b/cgi/CRMS.pm
@@ -42,6 +42,10 @@ sub new
   my $self = bless {}, $class;
   # Need not store the config, it's a singleton so subsequent calls to `new` will retrieve it.
   # This is the one-time setup.
+  # $args{instance} is only set when running one of the scripts in bin/ with the -t (training)
+  # or -p (production) flag. It is `undef` by default, and in a CGI environment.
+  # When $args{instance} is undef then CRMS::Config will pick the instance, if available,
+  # from ENV{CRMS_INSTANCE}.
   $self->{config} = CRMS::Config->new(instance => $args{instance});
   $self->SetupLogFile();
   # Initialize error reporting.
@@ -6422,10 +6426,10 @@ sub LinkNoteText
   my $self = shift;
   my $note = shift;
 
-  if ($note =~ m/See\sall\sreviews\sfor\sSys\s#(\d+)/)
+  if ($note =~ m/See all reviews for Sys #(\d+)/)
   {
     my $url = $self->WebPath('cgi', "crms?p=adminHistoricalReviews;stype=reviews;search1=SysID;search1value=$1");
-    $note =~ s/(See\sall\sreviews\sfor\sSys\s#)(\d+)/$1<a href="$url" target="_blank">$2<\/a>/;
+    $note =~ s/(See all reviews for Sys #)(\d+)/$1<a href="$url" target="_blank">$2<\/a>/;
   }
   return $note;
 }

--- a/cgi/CRMS.pm
+++ b/cgi/CRMS.pm
@@ -6387,14 +6387,14 @@ sub IsDevArea
 {
   my $self = shift;
 
-  return (CRMS::Config->new->instance eq 'development') ? 0 : 1;
+  return (CRMS::Config->new->instance eq 'development') ? 1 : 0;
 }
 
 sub IsTrainingArea
 {
   my $self = shift;
 
-  return (CRMS::Config->new->instance eq 'training') ? 0 : 1;
+  return (CRMS::Config->new->instance eq 'training') ? 1 : 0;
 }
 
 sub Hostname

--- a/cgi/CRMS.pm
+++ b/cgi/CRMS.pm
@@ -3425,7 +3425,7 @@ sub LinkToReview
 
   $title = $self->GetTitle($id) unless $title;
   $title = CGI::escapeHTML($title);
-  my $url = $self->Sysify($self->WebPath('cgi', "crms?p=review;htid=$id;editing=1"));
+  my $url = $self->WebPath('cgi', "crms?p=review;htid=$id;editing=1");
   $url .= ";importUser=$user" if $user;
   $self->ClearErrors();
   return "<a href='$url' target='_blank'>$title</a>";
@@ -6424,7 +6424,7 @@ sub LinkNoteText
 
   if ($note =~ m/See\sall\sreviews\sfor\sSys\s#(\d+)/)
   {
-    my $url = $self->Sysify($self->WebPath('cgi', "crms?p=adminHistoricalReviews;stype=reviews;search1=SysID;search1value=$1"));
+    my $url = $self->WebPath('cgi', "crms?p=adminHistoricalReviews;stype=reviews;search1=SysID;search1value=$1");
     $note =~ s/(See\sall\sreviews\sfor\sSys\s#)(\d+)/$1<a href="$url" target="_blank">$2<\/a>/;
   }
   return $note;
@@ -6835,7 +6835,7 @@ sub AddInheritanceToQueue
       my $n = $self->SimpleSqlGet($sql, $id);
       if ($n)
       {
-        my $url = $self->Sysify("?p=adminReviews;search1=Identifier;search1value=$id");
+        my $url = "?p=adminReviews;search1=Identifier;search1value=$id";
         my $msg = sprintf "already has $n <a href='$url' target='_blank'>%s</a>", $self->Pluralize('review',$n);
         push @msgs, $msg;
         $stat = 1;
@@ -7410,16 +7410,6 @@ sub Authorities
   return \@all;
 }
 
-# Previously used to make sure viral params were appended to generated URLs.
-# No longer needed -- can be removed.
-sub Sysify
-{
-  my $self = shift;
-  my $url  = shift;
-
-  return $url;
-}
-
 # Used to simplify the search results page links.
 # Makes URL params for all values defined in the CGI,
 # ignoring those that are valueless.
@@ -7459,15 +7449,6 @@ sub Hiddenify
     push @comps, "<input type='hidden' name='$key' value='$val'/>" if $val and not $exceptions{$key};
   }
   return join "\n", @comps;
-}
-
-# Previously used to make sure viral params were included in hidden input.
-# No longer needed -- can be removed.
-sub HiddenSys
-{
-  my $self = shift;
-
-  return '';
 }
 
 # Compares 2 strings or undefs. Returns 1 or 0 for equality.

--- a/cgi/CRMS.pm
+++ b/cgi/CRMS.pm
@@ -7129,7 +7129,7 @@ sub GetSystemVar
 
   my $sql = 'SELECT value FROM systemvars WHERE name=?';
   my $var = $self->SimpleSqlGet($sql, $name);
-  $var = $self->{'config'}->{$name} unless defined $var;
+  $var = CRMS::Config->new->config->{$name} unless defined $var;
   $var = $default unless defined $var;
   return $var;
 }

--- a/cgi/CRMS.pm
+++ b/cgi/CRMS.pm
@@ -425,12 +425,9 @@ sub GetSdrDb
 sub DSN {
   my $self = shift;
 
-  my $instance = $self->get('instance') || '';
   my $config = CRMS::Config->new;
   my $db_host = $config->config->{'db_host'};
-  $db_host = $config->config->{'db_host_development'} if $instance eq '';
   my $db_name = $config->config->{'db_name'};
-  $db_name = 'crms_training' if $instance eq 'crms-training';
   return "DBI:mysql:database=$db_name;host=$db_host";
 }
 

--- a/cgi/adminQueue.tt
+++ b/cgi/adminQueue.tt
@@ -42,10 +42,8 @@ function CheckAll(box,formid)
 <br/><br/>
 [% locked = crms.GetLockedItems() %]
 [% IF locked.size %]
-  [% url = crms.Sysify('crms?p=adminQueue;clear=1') %]
-  <blockquote><a href="$url">Clear old locks</a></blockquote><br/>
+  <blockquote><a href="crms?p=adminQueue;clear=1">Clear old locks</a></blockquote><br/>
   <form action="crms" id="checks">
-  [% crms.HiddenSys() %]
   <input type="hidden" name="p" value="adminQueue"/>
   <input type="checkbox" id="SelectAllCB" onclick="CheckAll(this,'checks');"/>
   <label for="SelectAllCB">Select All</label>&nbsp;&nbsp;&nbsp;&nbsp;
@@ -60,7 +58,7 @@ function CheckAll(box,formid)
       <td style="text-align:center">[% locked.${item}.locked %]</td>
       <td style="text-align:center"><input type="checkbox" name="vol_[% item %]"/></td>
       <td style="text-align:center">
-        [% url = crms.Sysify("crms?p=adminQueue;unlock=$item") %]
+        [% url = "crms?p=adminQueue;unlock=$item" %]
         <a href="$url">do it</a>
       </td>
     </tr>

--- a/cgi/adminUser.tt
+++ b/cgi/adminUser.tt
@@ -40,7 +40,6 @@ addEvent(window, 'load', function(e)
 
 <form action="crms">
   <input type="hidden" name="p" value="adminUser"/>
-  [% crms.HiddenSys() %]
   <label for="order">Order by:</label>
   <select name="order" id="order" onchange="this.form.submit()">
     <option value="0" [% (order==0)? 'selected="selected"':'' %]>Name</option>
@@ -94,12 +93,11 @@ addEvent(window, 'load', function(e)
     [% style = (active)? '':'style="background-color:#e2e2e2;"' %]
     <tr [% id == u.id ? 'class="total"':'class="hoverWide"'%] [% style %]>
       <td class="nowrap">
-        <a href="[% crms.Sysify('crms?p=userRate;user=' _ userid) %]" target="_blank">
+        <a href="[% 'crms?p=userRate;user=' _ userid %]" target="_blank">
           [% u.name.replace('\s','&nbsp;') %]
         </a>
         [% IF active && crms.CanChangeToUser(user,userid) %]
         <form action="crms" style="display:inline;align:right;">
-          [% crms.HiddenSys() %]
           <input type="hidden" name="changeuser" value="1"/>
           <input type="hidden" name="newuser" value="[% userid %]"/>
           <input type="submit" value="Change to…"/>
@@ -195,7 +193,6 @@ addEvent(window, 'load', function(e)
     <input type="hidden" name="p" value="adminUser"/>
     <input type="hidden" name="add" value="1"/>
     <input type="hidden" name="order" value="[% order %]"/>
-    [% crms.HiddenSys() %]
     <table>
     <tr>
       <td>

--- a/cgi/adminUserRate.tt
+++ b/cgi/adminUserRate.tt
@@ -13,7 +13,6 @@
 <div style="position:relative;border-style:solid;width:36em;border-width:1px;padding:10px;">
 <form id="select" action="crms">
 <input type="hidden" name="p" value="$p_page"/>
-[% crms.HiddenSys() %]
 
 [% projs = crms.GetProjectsRef() %]
 <label for="projectSel" style="width:5em;float:left;">Project</label>

--- a/cgi/bib_rights.tt
+++ b/cgi/bib_rights.tt
@@ -4,7 +4,6 @@
 
 <h2>Query Bibliographic Rights:</h2>
 <form action="crms">
-  [% crms.HiddenSys() %]
   <input type="hidden" name="p" value="[% p %]"/>
   <label for="queryTA" class="smallishText">Enter one volume or catalog id per line.</label><br/>
   <textarea id="queryTA" name="query" cols="20" rows="10" style="width:33%; height:9em;">[% crms.EchoInput(q) %]</textarea>

--- a/cgi/candidates.tt
+++ b/cgi/candidates.tt
@@ -44,7 +44,6 @@
 
 <form id="select" action="crms">
 <input type="hidden" name="p" value="$page"/>
-[% crms.HiddenSys() %]
 
 Restrict selection:<br/>
 

--- a/cgi/debug.tt
+++ b/cgi/debug.tt
@@ -11,7 +11,6 @@
   <th>List&nbsp;Unicode&nbsp;bibdata&nbsp;entries</th>
   <td>
     <form action="crms">
-      [% crms.HiddenSys() %]
       <input type="hidden" name="p" value="$page"/>
       <input type="hidden" name="multibyte" value="1"/>
       <input type="submit" value="Do it!"/>
@@ -22,7 +21,6 @@
   <th>List&nbsp;System&nbsp;variables</th>
   <td>
     <form action="crms">
-      [% crms.HiddenSys() %]
       <input type="hidden" name="p" value="$page"/>
       <input type="hidden" name="systemvars" value="1"/>
       <input type="submit" value="Do it!"/>
@@ -47,7 +45,6 @@
 <div style="position:relative;border-style:solid;width:66em;border-width:1px;padding:10px;">
 <h3>Export Report</h3>
 <form id="select" action="crms">
-  [% crms.HiddenSys() %]
   <input type="hidden" name="p" value="$page"/>
   <input type="hidden" name="export_report" value="1"/>
   <label for="startDate" style="width:5em;float:left;">YTD Start:</label>
@@ -135,7 +132,6 @@
 [% ids = cgi.param('ids') %]
 <h4>Update Bibliographic Data</h4>
 <form action="crms">
-  [% crms.HiddenSys() %]
   <input type="hidden" name="p" value="debug"/>
   <input type="hidden" name="fix" value="1"/>
   <p class="smallishText">Enter one volume id per line.</p>
@@ -149,7 +145,6 @@
 <div style="position:relative;border-style:solid;width:76em;border-width:1px;padding:10px;">
   <h4>Remove From Candidates</h4>
   <form action="crms">
-    [% crms.HiddenSys() %]
     <input type="hidden" name="p" value="debug"/>
     <input type="hidden" name="deleteFromCandidates" value="1"/>
     <p class="smallishText">Enter one volume id per line.</p>

--- a/cgi/denied.tt
+++ b/cgi/denied.tt
@@ -16,8 +16,8 @@
     [% username = (user)? user : "{unknown user}" %]
     <h2>You do not have access to this page.</h2>
     [% IF user %]
-      <strong><a href="[% crms.Sysify('?p=home') %]">Go to home page</a></strong><br/>
-      <strong><a href="[% crms.Sysify('?p=Logout') %]"> Logout</a></strong>
+      <strong><a href="?p=home">Go to home page</a></strong><br/>
+      <strong><a href="?p=Logout"> Logout</a></strong>
     [% END %]
     <div class="warningSubbox">
       <h4>Security considerations do not allow Copyright Review Management System reviewer

--- a/cgi/expired.tt
+++ b/cgi/expired.tt
@@ -15,7 +15,7 @@
   [% user = crms.get('user') %]
   <div class="warningBox">
     <h2>Hello [% crms.GetUserProperty(user, 'name') %]. You do not have access to this site.</h2>
-    <strong><a href="[% crms.Sysify('?p=Logout') %]"> Logout</a></strong>
+    <strong><a href="?p=Logout"> Logout</a></strong>
   
     <div class="warningSubbox">
       <h4>Your access to in-copyright HathiTrust scans expired [% exp.expires %].

--- a/cgi/exportDataSelection.tt
+++ b/cgi/exportDataSelection.tt
@@ -32,7 +32,6 @@
 
 <form id="select" action="crms">
 <input type="hidden" name="p" value="$page"/>
-[% crms.HiddenSys() %]
 
 Restrict selection:<br/>
 

--- a/cgi/header.tt
+++ b/cgi/header.tt
@@ -46,11 +46,11 @@
          [% status = (r.1 == 'down')? 'unavailable':((r.1 == 'partial')? 'partially available':r.1) %]
          <span style="font-size:1.3em;text-align:center;color:#DD4444">System status is <b>[% status %]</b>; last modified [% r.0 %]</span><br/>
          <span style="font-size:1.1em;">[% r.2 %]</span>
-         [% IF page == 'review' %]&nbsp;&nbsp;&nbsp;<a href="[% crms.Sysify('crms') %]">Home</a>[% END %]
+         [% IF page == 'review' %]&nbsp;&nbsp;&nbsp;<a href="crms">Home</a>[% END %]
         </td></tr>
         </table>
       [% ELSE %]
-      <a href="[% crms.Sysify('crms') %]">
+      <a href="crms">
         <img src="[% crms.WebPath('web', crms.GetSystemVar('logo')) %]" width="455" height="80" alt="Jump to home page"
              style="float:left;border:0px solid;margin-right:4em;"/>
       </a>
@@ -64,7 +64,7 @@
             </td>
             <td style="line-height:1px;">
               Hello&nbsp;[% crms.GetUserProperty(undef, 'name').replace(" ","&nbsp;") %]&nbsp;&nbsp;
-              <a href="[% crms.Sysify(crms.WebPath('cgi', 'crms?p=Logout')) %]" class="header">Log Out</a>
+              <a href="?p=Logout" class="header">Log Out</a>
             </td>
           </tr>
           <tr>

--- a/cgi/home.tt
+++ b/cgi/home.tt
@@ -28,7 +28,6 @@ function CheckAll(box,formid)
 [% IF projs.size > 1 %]
   <form action="crms">
     <input type="hidden" name="projectForm" value="1"/>
-    [% crms.HiddenSys() %]
     <label for="projectSel">Current project:</label>
     <select name="projectSel" id="projectSel" onchange="this.form.submit()">
     [% FOREACH proj IN projs %]
@@ -52,7 +51,7 @@ function CheckAll(box,formid)
 [% n = ref.size %]
 [% IF n>0 %]
   <h4>You have $n
-    <a href="[% crms.Sysify('?p=queueAdd') %]">
+    <a href="?p=queueAdd">
     high-priority</a> [% crms.Pluralize('volume', n) %].
   </h4>
 [% END %]
@@ -118,7 +117,6 @@ function CheckAll(box,formid)
 [% IF locked.size %]
   [% sysStatus = crms.GetSystemStatus().1 %]
   <br/><br/><form action="crms" id="checks">
-  [% crms.HiddenSys() %]
   <input type="checkbox" id="SelectAllCB" onclick="CheckAll(this,'checks');"/>
   <label for="SelectAllCB">Select All</label>&nbsp;&nbsp;&nbsp;&nbsp;
   [% IF sysStatus == 'normal' %]
@@ -135,7 +133,7 @@ function CheckAll(box,formid)
       <td>[% crms.GetTitle( item ) %]</td>
       <td style="text-align:center"><input type="checkbox" name="vol_[% item %]"/></td>
       <td style="text-align:center">
-        [% IF sysStatus == 'normal' %]<a href="[% crms.Sysify("crms?unlock=" _ item) %]">do it</a>[% END %]
+        [% IF sysStatus == 'normal' %]<a href="[% 'crms?unlock=' _ item %]">do it</a>[% END %]
       </td>
     </tr>
   [% END %]

--- a/cgi/inherit.tt
+++ b/cgi/inherit.tt
@@ -44,7 +44,6 @@ may not be up-to-date.</h3>
 <input type="hidden" name="p" value="$p"/>
 <input type="hidden" name="auto" value="$auto"/>
 <input type="hidden" name="n" value="$n"/>
-[% crms.HiddenSys() %]
 
 Restrict selection:
 <div style="position:absolute;top:0.5em;right:0.5em;">
@@ -229,7 +228,6 @@ function EnableButtons(formid)
     <input type="hidden" name="p" value="$p"/>
     <input type="hidden" name="auto" value="$auto"/>
     <input type="hidden" name="n" value="$n"/>
-    [% crms.HiddenSys() %]
     <input type="checkbox" id='SelectAllButton' onclick="CheckAll(this,'checks');"/>
     <label for="SelectAllButton">Select All</label>
     &nbsp;&nbsp;&nbsp;&nbsp;

--- a/cgi/institutions.tt
+++ b/cgi/institutions.tt
@@ -11,7 +11,6 @@
 
 <form action="crms">
   <input type="hidden" name="p" value="institutions"/>
-  [% crms.HiddenSys() %]
   <label for="order">Order by:</label>
   <select name="order" id="order" onchange="this.form.submit()">
     <option value="id" [% (order=='id')? 'selected="selected"':'' %]>ID</option>
@@ -49,7 +48,7 @@
     <tr [% id == iid ? 'class="total"':'class="hoverWide"'%] [% style %]>
       <td>[% id %]</td>
       <td class="nowrap">
-        <a href="[% crms.Sysify('crms?p=adminUserRate;institution=' _ id) %]">
+        <a href="[% 'crms?p=adminUserRate;institution=' _ id %]">
           [% inst.name.replace('\s','&nbsp;') %]
         </a>
       </td>
@@ -73,7 +72,6 @@
     <input type="hidden" name="p" value="institutions"/>
     <input type="hidden" name="add" value="1"/>
     <input type="hidden" name="order" value="[% order %]"/>
-    [% crms.HiddenSys() %]
     <table>
       <tr>
         <td>

--- a/cgi/keio.tt
+++ b/cgi/keio.tt
@@ -22,7 +22,6 @@ addEvent(window, 'load', function(e)
 [% END %]
 <form action="crms">
   <input type="hidden" name="p" value="keio"/>
-  [% crms.HiddenSys() %]
   <label for="table_sel">Table:</label>
   <select name="table" id="table_sel" onchange="selMenuItem('query_sel', 0);selMenuItem('page_sel', 0);this.form.submit()">
     <option value=""></option>

--- a/cgi/licensing.tt
+++ b/cgi/licensing.tt
@@ -5,7 +5,6 @@
 
 <h2>Licensing:</h2>
 <form action="crms">
-  [% crms.HiddenSys() %]
   <input type="hidden" name="p" value="[% p %]"/>
   <label for="queryTA" class="smallishText">Enter one volume or system id per line.</label><br/>
   <textarea id="queryTA" name="query" cols="20" rows="10" style="width:33%; height:9em;">[% crms.EchoInput(q) %]</textarea>
@@ -14,7 +13,6 @@
 
 [% IF q %]
   <form action="crms" method="POST">
-    [% crms.HiddenSys() %]
     <input type="hidden" name="p" value="[% p %]"/>
     [% IF cgi.param("submit_rights") == "true" %]
       <br/><strong>Data Submitted</strong><br/>

--- a/cgi/mail.tt
+++ b/cgi/mail.tt
@@ -57,7 +57,6 @@ function closeMe()
         <br/>
         [% user = crms.get('user') %]
         <form action="crms">
-          [% crms.HiddenSys() %]
           <input type="hidden" name="user" value="[% user %]"/>
           <input type="hidden" name="p" value="[% cgi.param('p') %]"/>
           <input type="hidden" name="uuid" value="[% crms.UUID() %]"/>

--- a/cgi/nav.tt
+++ b/cgi/nav.tt
@@ -9,7 +9,7 @@ addEvent(window, 'load', sfHover);
 [% IF p %]
   <li><span>Home</span>
   <dl class="home">
-    <dt><a href="[% crms.Sysify("crms") %]">Home</a></dt>
+    <dt><a href="crms">Home</a></dt>
     <dd style="display:none"> </dd>
   </dl>
   </li>

--- a/cgi/partial/top.tt
+++ b/cgi/partial/top.tt
@@ -11,7 +11,7 @@
     <tr>
       <td style="text-align:left;padding-left:8px;">
         <a href="[% homeLink %]">Home</a>
-        &nbsp;&nbsp;&nbsp;&nbsp;<a href="[% crms.Sysify(crms.WebPath('cgi', 'crms?p=Logout')) %]">Logout</a>
+        &nbsp;&nbsp;&nbsp;&nbsp;<a href="?p=Logout">Logout</a>
       </td>
     </tr>
     <tr>

--- a/cgi/queueAdd.tt
+++ b/cgi/queueAdd.tt
@@ -167,7 +167,6 @@ function CheckAllTx(box,id)
   </table>
   [% IF admin %]
   <form action="crms" id="checks1">
-  [% crms.HiddenSys() %]
   <input type="hidden" name="p" value="queueAdd"/>
   <input type="submit" name="delSel" value="Delete Selection"/><br/><br/>
   [% END %]
@@ -216,7 +215,7 @@ function CheckAllTx(box,id)
       [% END %]
       <td>
         [% IF r.added_by == user %]
-          <a href="[% crms.Sysify('crms?p=review;editing=1;htid=' _  r.id) %]" target="_blank">Review</a>
+          <a href="[% 'crms?p=review;editing=1;htid=' _  r.id %]" target="_blank">Review</a>
         [% END %]
       </td>
       <td>[% crms.CurrentRightsQuery(r.id).replace('\s','&nbsp;') %]</td>
@@ -225,9 +224,9 @@ function CheckAllTx(box,id)
       <td>[% r.pub_date %]</td>
       <td class="nowrap">
       [% IF r.status > 0 %]
-        <a href="[% crms.Sysify('?p=adminReviews;search1=Identifier;search1value=' _ r.id) %]" target="_blank">
+        <a href="[% '?p=adminReviews;search1=Identifier;search1value=' _ r.id %]" target="_blank">
       [% ELSE %]
-        <a href="[% crms.Sysify('?p=queue;search1=Identifier;search1value=' _ r.id) %]" target="_blank">
+        <a href="[% '?p=queue;search1=Identifier;search1value=' _ r.id %]" target="_blank">
       [% END %]
       [% r.id %]</a></td>
       <td>[% r.date %]</td>

--- a/cgi/queueSelection.tt
+++ b/cgi/queueSelection.tt
@@ -30,7 +30,6 @@
 
 <form id="select" action="crms">
 <input type="hidden" name="p" value="$page"/>
-[% crms.HiddenSys() %]
 
 Restrict selection:<br/>
 

--- a/cgi/selection.tt
+++ b/cgi/selection.tt
@@ -48,7 +48,6 @@
 
 <form id="select" action="crms">
 <input type="hidden" name="p" value="$page"/>
-[% crms.HiddenSys() %]
 [% IF page != 'editReviews' && page != 'userReviews' && page != 'holds' %]
   <label for="stype">Search for:</label>
   <select name="stype" id="stype">

--- a/cgi/systemStatus.tt
+++ b/cgi/systemStatus.tt
@@ -35,7 +35,6 @@ function limitText(limitField, limitCount, limitNum)
   <p class="smallishText">Enter a message to be displayed on every page of the CRMS.<br/>
   (Max 150 characters; <input readonly="readonly" type="text" name="countdown" size="3" value="150"/> left.)</p>
 
-  [% crms.HiddenSys() %]
   <input type="hidden" name="p" value="systemStatus"/>
   <input type="hidden" name="setStatus" value="1"/>
   <textarea name="msg" cols="20" rows="3" style="width:33%;"
@@ -62,7 +61,6 @@ To display a custom message, or override the standard ones (<i>down</i>/<i>parti
 [% autoinherit = ('disabled' != crms.GetSystemVar('autoinherit')) %]
 <form action="crms">
   <h4>Automatic Rights Inheritance:</h4><br/>
-  [% crms.HiddenSys() %]
   <input type="hidden" name="p" value="systemStatus"/>
   <input type="hidden" name="setAutoinherit" value="1"/>
   <table class="exportStats">

--- a/cgi/track.tt
+++ b/cgi/track.tt
@@ -4,7 +4,6 @@
 
 <h2>Track Volumes:</h2>
 <form action="crms">
-  [% crms.HiddenSys() %]
   <input type="hidden" name="p" value="[% p %]"/>
   <label for="queryTA" class="smallishText">Enter one volume or system id per line.</label><br/>
   <textarea id="queryTA" name="query" cols="20" rows="10" style="width:33%; height:9em;">[% crms.EchoInput(q) %]</textarea>
@@ -26,7 +25,7 @@
     [% seen.$sysid = 1 %]
     <br/><br/>
     [% IF sysid %]
-      [% url = crms.Sysify("?p=$p;download=1;q=$id") %]
+      [% url = "?p=$p;download=1;q=$id" %]
       <a href="[% url %]" target="_blank">Download</a>
     [% END %]
     <table class="exportStats">

--- a/cgi/und.tt
+++ b/cgi/und.tt
@@ -44,7 +44,6 @@
 
 <form id="select" action="crms">
 <input type="hidden" name="p" value="$page"/>
-[% crms.HiddenSys() %]
 
 Restrict selection:<br/>
 

--- a/config/config.local.yml.sample
+++ b/config/config.local.yml.sample
@@ -1,3 +1,7 @@
 # config.local.yml values override values in config.yml and
 # are for Apache deployments.
 host: sample.hathitrust.org
+# Used in CRMS::Config test -- will return empty string
+missing_subkey_test:
+  development: missing_subkey_test_development
+  production: missing_subkey_test_production

--- a/config/config.yml
+++ b/config/config.yml
@@ -20,9 +20,14 @@ hathitrust_logo: img/hathitrust-icon-orange-rgb.png
 ## mysql server connection settings
 ## ================================================================== ##
 # The hostname for the database where your CRMS data will be stored.
-db_host: mysql-sdr
-db_host_development: mysql-sdr
-db_name: crms
+db_host:
+  development: mysql-htdev
+  production: mysql-sdr
+  training: mysql-sdr
+db_name:
+  development: crms
+  production: crms
+  training: crms_training
 # The hostname for the HathiTrust database (read-only access).
 ht_db_host: mysql-sdr
 ht_db_name: ht

--- a/config/credentials.local.yml.sample
+++ b/config/credentials.local.yml.sample
@@ -1,3 +1,3 @@
 # credentials.local.yml values override values in credentials.yml and
 # are for Apache deployments.
-data_api_access_key: sample_value
+db_user: sample_value

--- a/config/credentials.yml
+++ b/config/credentials.yml
@@ -1,7 +1,13 @@
 db_user: crms
-db_password: crms
+db_password:
+  development: crms
+  training: crms
+  production: crms
 ht_db_user: mdp-lib
-ht_db_password: mdp-lib
+ht_db_password:
+  development: mdp-lib
+  training: mdp-lib
+  production: mdp-lib
 jira_user: crms
 jira_password: crms
 data_api_access_key: crms

--- a/config/credentials.yml
+++ b/config/credentials.yml
@@ -10,5 +10,3 @@ ht_db_password:
   production: mdp-lib
 jira_user: crms
 jira_password: crms
-data_api_access_key: crms
-data_api_secret_key: crms

--- a/config/credentials.yml
+++ b/config/credentials.yml
@@ -1,8 +1,8 @@
 db_user: crms
 db_password:
   development: crms
-  training: crms
-  production: crms
+  training: crms_training
+  production: crms_production
 ht_db_user: mdp-lib
 ht_db_password:
   development: mdp-lib

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,6 @@ services:
     environment:
       - SDRROOT=/htapps/babel
       - CRMS_DB_HOST=mariadb
-      - CRMS_DB_HOST_DEVELOPMENT=mariadb
       - CRMS_HT_DB_HOST=mariadb_ht
       # pass through info needed by coveralls uploader
       - GITHUB_TOKEN

--- a/lib/CRMS/Config.pm
+++ b/lib/CRMS/Config.pm
@@ -92,10 +92,8 @@ sub _read_config_files {
       my $value = $contents->{$key};
       # If the value is a hash, look for {production, training, development} subkeys.
       if (ref $value eq 'HASH') {
-        $value = $value->{$self->instance};
-        if (!defined $value) {
-          die "No value for $key in " . $self->instance . "\n";
-        }
+        # If misconfigured and instance is not available, use empty string.
+        $value = $value->{$self->instance} || '';
       }
       $config->{$key} = $value;
     }

--- a/lib/CRMS/Config.pm
+++ b/lib/CRMS/Config.pm
@@ -57,14 +57,15 @@ sub new {
 
 # The canonical name for the instance which can be used as a subkey for per-instance config.
 # Translate CRMS_INSTANCE value into canonical non-empty string.
-# We allow some leeway with the (input-side) training name because, well, why not.
-# The "correct" value of CRMS_INSTANCE for training is "crms-training" for the record.
-# The database name is "crms_training". They are easily confused. Hence the canonicalization.
 sub translate_instance_name {
   my $inst = shift || $ENV{CRMS_INSTANCE} || '';
 
   return 'production' if $inst eq 'production';
-  return 'training' if $inst eq 'crms-training' || $inst eq 'crms_training' || $inst eq 'training';
+  # Allow some leeway with the (input-side) training name because, well, why not.
+  # The "correct" value of CRMS_INSTANCE for training is "crms-training" for the record.
+  # The database name is "crms_training". They are easily confused.
+  # Hence the canonicalization, and the regex.
+  return 'training' if $inst =~ /training/;
   return 'development';
 }
 

--- a/lib/CRMS/Config.pm
+++ b/lib/CRMS/Config.pm
@@ -67,15 +67,12 @@ sub config {
 
 # Read credentials.yml (and credentials.local.yml if it exists)
 # and overwrite any keys with values found in ENV.
+# This structure is not cached as it might be exposed by Data::Dumper or the like.
 sub credentials {
   my $self = shift;
 
-  # uncoverable branch false
-  if (!defined $self->{credentials}) {
-    my $credentials = $self->_read_config_files('credentials');
-    $self->{credentials} = $self->_merge_env($credentials);
-  }
-  return $self->{credentials};
+  my $credentials = $self->_read_config_files('credentials');
+  return $self->_merge_env($credentials);
 }
 
 # Read basename.yml and basename.local.yml, merging values from the latter into the former.

--- a/lib/CRMS/Version.pm
+++ b/lib/CRMS/Version.pm
@@ -3,6 +3,6 @@ package CRMS::Version;
 use strict;
 use warnings;
 
-our $VERSION = '8.6.8';
+our $VERSION = '8.6.9';
 
 1;

--- a/t/CRMS.t
+++ b/t/CRMS.t
@@ -45,6 +45,8 @@ subtest 'CRMS::MoveToHathitrustFiles' => sub {
   my $tempdir = File::Temp::tempdir(CLEANUP => 1);
   my $save_hathitrust_files_directory = $ENV{'CRMS_HATHITRUST_FILES_DIRECTORY'};
   $ENV{'CRMS_HATHITRUST_FILES_DIRECTORY'} = $tempdir;
+  # Reload to pick up changes to ENV
+  CRMS::Config->new(reinitialize => 1);
   my $crms = CRMS->new('cgi' => $cgi);
   my $src1 = $crms->FSPath('prep', 'test_1.txt');
   my $src2 = $crms->FSPath('prep', 'test_2.txt');

--- a/t/CRMS.t
+++ b/t/CRMS.t
@@ -4,12 +4,12 @@ use strict;
 use warnings;
 use utf8;
 
-use lib "$ENV{SDRROOT}/crms/cgi";
-
 use File::Temp;
 use Test::More;
 
-require_ok($ENV{'SDRROOT'}. '/crms/cgi/CRMS.pm');
+use lib "$ENV{SDRROOT}/crms/cgi";
+use CRMS;
+
 my $cgi = CGI->new();
 my $crms = CRMS->new('cgi' => $cgi, 'verbose' => 0);
 ok(defined $crms, 'CRMS object created');

--- a/t/Config.t
+++ b/t/Config.t
@@ -20,6 +20,23 @@ subtest 'CRMS::Config::config' => sub {
   ok(ref $config eq 'HASH');
 };
 
+subtest 'CRMS::Config::instance' => sub {
+  subtest 'CRMS::Config::instance production' => sub {
+    my $instance = CRMS::Config->new(instance => 'production')->instance;
+    is($instance, 'production');
+  };
+
+  subtest 'CRMS::Config::instance training' => sub {
+    my $instance = CRMS::Config->new(instance => 'crms-training')->instance;
+    is($instance, 'training');
+  };
+
+  subtest 'CRMS::Config::instance development' => sub {
+    my $instance = CRMS::Config->new(instance => '')->instance;
+    is($instance, 'development');
+  };
+};
+
 subtest 'CRMS::Config::config with overriding ENV' => sub {
   my $save_env = $ENV{'CRMS_DB_HOST'};
   $ENV{'CRMS_DB_HOST'} = 'test_crms_db_host_value';

--- a/t/Config.t
+++ b/t/Config.t
@@ -13,34 +13,48 @@ use CRMS::Config;
 subtest 'CRMS::Config' => sub {
   my $config = CRMS::Config->new;
   ok(ref $config eq 'CRMS::Config');
-};
 
-subtest 'CRMS::Config::config' => sub {
-  my $config = CRMS::Config->new->config;
-  ok(ref $config eq 'HASH');
+  subtest 'CRMS::Config is singleton' => sub {
+    is_deeply($config, CRMS::Config->new);
+  };
 };
 
 subtest 'CRMS::Config::instance' => sub {
   subtest 'CRMS::Config::instance production' => sub {
-    my $instance = CRMS::Config->new(instance => 'production')->instance;
+    my $instance = CRMS::Config->new(reinitialize => 1, instance => 'production')->instance;
     is($instance, 'production');
   };
 
   subtest 'CRMS::Config::instance training' => sub {
-    my $instance = CRMS::Config->new(instance => 'crms-training')->instance;
-    is($instance, 'training');
+    my @variants = qw(crms-training crms_training training);
+    foreach my $variant (@variants) {
+      my $instance = CRMS::Config->new(reinitialize => 1, instance => $variant)->instance;
+      is($instance, 'training');
+    }
   };
 
   subtest 'CRMS::Config::instance development' => sub {
-    my $instance = CRMS::Config->new(instance => '')->instance;
+    my $instance = CRMS::Config->new(reinitialize => 1, instance => '')->instance;
     is($instance, 'development');
+
+    subtest 'CRMS::Config with no instance param and no ENV defaults to `development`' => sub {
+      $ENV{CRMS_INSTANCE} = 'development';
+      my $instance = CRMS::Config->new(reinitialize => 1)->instance;
+      is($instance, 'development');
+      delete $ENV{CRMS_INSTANCE};
+    };
   };
+};
+
+subtest 'CRMS::Config::config' => sub {
+  my $config = CRMS::Config->new(reinitialize => 1)->config;
+  ok(ref $config eq 'HASH');
 };
 
 subtest 'CRMS::Config::config with overriding ENV' => sub {
   my $save_env = $ENV{'CRMS_DB_HOST'};
   $ENV{'CRMS_DB_HOST'} = 'test_crms_db_host_value';
-  my $config = CRMS::Config->new->config;
+  my $config = CRMS::Config->new(reinitialize => 1)->config;
   is($config->{'db_host'}, 'test_crms_db_host_value');
   $ENV{'CRMS_DB_HOST'} = $save_env;
 };
@@ -49,20 +63,29 @@ subtest 'CRMS::Config::config with config.local.yml' => sub {
   my $config_local_sample = $ENV{'SDRROOT'} . '/crms/config/config.local.yml.sample';
   my $config_local = $ENV{'SDRROOT'} . '/crms/config/config.local.yml';
   File::Copy::copy($config_local_sample, $config_local) or Carp::confess "Copy failed: $!";
-  my $config = CRMS::Config->new->config;
-  is($config->{'host'}, 'sample.hathitrust.org');
+
+  subtest 'subkey present' => sub {
+    my $config = CRMS::Config->new(reinitialize => 1)->config;
+    is($config->{'missing_subkey_test'}, 'missing_subkey_test_development');
+  };
+
+  subtest 'subkey missing' => sub {
+    my $config = CRMS::Config->new(reinitialize => 1, instance => 'training')->config;
+    is($config->{'missing_subkey_test'}, '');
+  };
+
   unlink $config_local;
 };
 
 subtest 'CRMS::Config::credentials' => sub {
-  my $credentials = CRMS::Config->new->credentials;
+  my $credentials = CRMS::Config->new(reinitialize => 1)->credentials;
   ok(ref $credentials eq 'HASH');
 };
 
 subtest 'CRMS::Config::credentials with overriding ENV' => sub {
   my $save_env = $ENV{'CRMS_DB_USER'};
   $ENV{'CRMS_DB_USER'} = 'test_crms_db_user_value';
-  my $credentials = CRMS::Config->new->credentials;
+  my $credentials = CRMS::Config->new(reinitialize => 1)->credentials;
   is($credentials->{'db_user'}, 'test_crms_db_user_value');
   $ENV{'CRMS_DB_USER'} = $save_env;
 };
@@ -71,13 +94,13 @@ subtest 'CRMS::Config::credentials with credentials.local.yml' => sub {
   my $credentials_local_sample = $ENV{'SDRROOT'} . '/crms/config/credentials.local.yml.sample';
   my $credentials_local = $ENV{'SDRROOT'} . '/crms/config/credentials.local.yml';
   File::Copy::copy($credentials_local_sample, $credentials_local) or Carp::confess "Copy failed: $!";
-  my $credentials = CRMS::Config->new->credentials;
+  my $credentials = CRMS::Config->new(reinitialize => 1)->credentials;
   is($credentials->{'db_user'}, 'sample_value');
   unlink $credentials_local;
 };
 
 subtest 'sanity check config keys' => sub {
-  my $config = CRMS::Config->new;
+  my $config = CRMS::Config->new(reinitialize => 1);
   foreach my $key (keys %{$config->config}) {
     ok($key =~ m/^[a-z_]+$/, "check key $key");
   }
@@ -87,7 +110,7 @@ subtest 'sanity check config keys' => sub {
 };
 
 subtest 'database config for crms_training instance' => sub {
-  my $config = CRMS::Config->new(instance => 'crms_training');
+  my $config = CRMS::Config->new(reinitialize => 1, instance => 'crms_training');
   # docker-compose ENV messes with db_host and we don't have different values for db_user
   is($config->config->{'db_name'}, 'crms_training');
   is($config->credentials->{'db_password'}, 'crms_training');

--- a/t/Config.t
+++ b/t/Config.t
@@ -69,5 +69,12 @@ subtest 'sanity check config keys' => sub {
   }
 };
 
+subtest 'database config for crms_training instance' => sub {
+  my $config = CRMS::Config->new(instance => 'crms_training');
+  # docker-compose ENV messes with db_host and we don't have different values for db_user
+  is($config->config->{'db_name'}, 'crms_training');
+  is($config->credentials->{'db_password'}, 'crms_training');
+};
+
 
 done_testing();

--- a/t/Config.t
+++ b/t/Config.t
@@ -55,7 +55,7 @@ subtest 'CRMS::Config::credentials with credentials.local.yml' => sub {
   my $credentials_local = $ENV{'SDRROOT'} . '/crms/config/credentials.local.yml';
   File::Copy::copy($credentials_local_sample, $credentials_local) or Carp::confess "Copy failed: $!";
   my $credentials = CRMS::Config->new->credentials;
-  is($credentials->{'data_api_access_key'}, 'sample_value');
+  is($credentials->{'db_user'}, 'sample_value');
   unlink $credentials_local;
 };
 

--- a/t/Cron.t
+++ b/t/Cron.t
@@ -12,8 +12,8 @@ use lib "$ENV{SDRROOT}/crms/cgi";
 use lib "$ENV{SDRROOT}/crms/lib";
 
 use CRMS;
+use CRMS::Cron;
 
-require_ok($ENV{'SDRROOT'}. '/crms/lib/CRMS/Cron.pm');
 my $crms = CRMS->new;
 my $cron = CRMS::Cron->new('crms' => $crms);
 


### PR DESCRIPTION
- Changes to DB credentials break a longstanding assumption that dev and prod DB passwords are the same.
- `CRMS::Config` module can now understand YAML subkeys that are {production, training, development}.
- TIDY commits can be ignored. There was some cruft adjacent to this ticket that screamed for removal.

Reviewer:
- The profusion of files touched can be mostly laid at the feet of the last few TIDY commits.
- I am mainly interested in the emerging shape of `lib/CRMS/Auth.pm`
  - The "singletonizing" effort should make it possible to decouple the 200-pound CRMS object from data models (CRMS.pm is like the `$C` that gets passed around everywhere in `babel`).