### PR TITLE
ETT-500 Create a User Agent for CRMS when using Stanford API

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -50,3 +50,5 @@ rights_export_directory: /htapps/babel/feed/var/rights
 hathitrust_files_directory: /htapps/www/files
 # Used by Jira.pm
 jira_prefix: https://hathitrust.atlassian.net
+# Used when connecting to Stanford API, potentially other services.
+crms_user_agent: HathiTrust-CRMS


### PR DESCRIPTION
Stanford have carved out an exception for a new User-Agent string of our choice, for use when we request data of their copyright renewal API. Recently they began enforcing a block policy which was shutting us out since we are behind Cloudflare and presumed to be malicious traffic.

- Add a `crms_user_agent` field to the config YML. It's for Stanford but we could use it elsewhere if needed.
- `Stanford.pm` uses this config when setting up a user agent for running a query against the Stanford API.
- TIDY: remove an unused variable, consolidate args to `LWP::UserAgent->new`.

Reviewer: this module is not under test so a visual inspection will suffice. `Stanford.pm` lines 21-25 are the change of note.