### PR TITLE
ETT-752 sbcr project

### DIFF
--- a/cgi/CRMS.pm
+++ b/cgi/CRMS.pm
@@ -8022,6 +8022,8 @@ sub Field008Formatter {
 }
 
 # TODO: move to a Utilities class or module.
+# Right now the partials do not have access to the Utilities module directly
+# so until that gets refactored keep this here so it can be used in a template.
 # This is only used with output of CRMS::Rights for the rights.tt partial.
 sub array_to_pairs {
   my $self  = shift;
@@ -8032,8 +8034,8 @@ sub array_to_pairs {
     return $pairs;
   }
   foreach my $element (@$array) {
-    # If there is nothing in the pairs list, or if the last entry contains two elements, add a new one-item pair
-    # Otherwise add second pair to last element
+    # If there is nothing in the pairs list, or if the last entry contains two elements, add a new one-item arrayref.
+    # Otherwise add as the second half of the pair under construction.
     if (scalar @$pairs == 0 || scalar @{$pairs->[-1]} == 2) {
       push @$pairs, [$element];
     } else {

--- a/cgi/CRMS.pm
+++ b/cgi/CRMS.pm
@@ -8021,4 +8021,30 @@ sub Field008Formatter {
   CRMS::Field008Formatter->new;
 }
 
+# TODO: move to a Utilities class or module.
+# This is only used with output of CRMS::Rights for the rights.tt partial.
+sub array_to_pairs {
+  my $self  = shift;
+  my $array = shift;
+
+  my $pairs = [];
+  if (!scalar @$array) {
+    return $pairs;
+  }
+  foreach my $element (@$array) {
+    # If there is nothing in the pairs list, or if the last entry contains two elements, add a new one-item pair
+    # Otherwise add second pair to last element
+    if (scalar @$pairs == 0 || scalar @{$pairs->[-1]} == 2) {
+      push @$pairs, [$element];
+    } else {
+      push @{$pairs->[-1]}, $element;
+    }
+  }
+  # Final non-pair in case of odd array, [x] -> [x, undef]
+  if (scalar @{$pairs->[-1]} == 1) {
+    push @{$pairs->[-1]}, undef;
+  }
+  return $pairs;
+}
+
 1;

--- a/cgi/CRMS.pm
+++ b/cgi/CRMS.pm
@@ -7279,7 +7279,8 @@ sub Rights
   my $proj = $self->SimpleSqlGet('SELECT project FROM queue WHERE id=?', $id);
   $proj = 1 unless defined $proj;
   my @all = ();
-  my $sql = 'SELECT r.id,CONCAT(a.name,"/",rs.name),r.description,a.name,rs.name FROM rights r'.
+  my $sql = 'SELECT r.id,CONCAT(a.name,"/",rs.name),r.description,a.name,rs.name,a.dscr,rs.dscr'.
+            ' FROM rights r'.
             ' INNER JOIN attributes a ON r.attr=a.id'.
             ' INNER JOIN reasons rs ON r.reason=rs.id'.
             ' INNER JOIN projectrights pr ON r.id=pr.rights'.
@@ -7293,7 +7294,8 @@ sub Rights
   {
     push @all, {'id' => $row->[0], 'rights' => $row->[1],
                 'description' => $row->[2], 'n' => $n,
-                'attr' => $row->[3], 'reason' => $row->[4]};
+                'attr' => $row->[3], 'reason' => $row->[4],
+                'attr_dscr' => $row->[5], 'reason_dscr' => $row->[6]};
     $n++;
   }
   return \@all if $order;

--- a/cgi/Project/SBCR.pm
+++ b/cgi/Project/SBCR.pm
@@ -1,0 +1,44 @@
+package SBCR;
+use parent 'Project';
+
+use strict;
+use warnings;
+
+sub new {
+  my $class = shift;
+  return $class->SUPER::new(@_);
+}
+
+# ========== REVIEW ========== #
+# TODO
+sub ValidateSubmission {
+  my $self = shift;
+  my $cgi  = shift;
+
+  my $rights = $cgi->param('rights');
+  return if $rights;
+  return 'You must select a rights/reason combination';
+}
+
+# Extract Project-specific data from the CGI into a struct
+# that will be encoded as JSON string in the reviewdata table.
+sub ExtractReviewData {
+  my $self = shift;
+  my $cgi  = shift;
+
+  my $renNum = $cgi->param('renNum') || '';
+  my $renDate = $cgi->param('renDate') || '';
+  my $actualPubDate = $cgi->param('actualPubDate') || '';
+  my $data = {};
+  $data->{'renNum'} = $renNum if $renNum;
+  $data->{'renDate'} = $renDate if $renDate;
+  $data->{'actualPubDate'} = $actualPubDate if $actualPubDate;
+  return $data;
+}
+
+sub ReviewPartials {
+  return ['top', 'bibdata_sbcr', 'authorities',
+          'sbcr_form', 'expertDetails'];
+}
+
+1;

--- a/cgi/Project/SBCR.pm
+++ b/cgi/Project/SBCR.pm
@@ -59,6 +59,9 @@ sub ValidateSubmission {
       push @errs, 'pd/ren should not include renewal info';
     }
   }
+  if ($actual && $actual !~ m/^\d{4}(-\d{4})?$/) {
+    push @errs, 'Actual Publication Date must be a date or a date range (DDDD or DDDD-DDDD)';
+  }
   ## pd*/cdpp must not have a ren number
   if (($attr eq 'pd' || $attr eq 'pdus') && $reason eq 'cdpp' && ($renNum || $renDate)) {
     push @errs, "$attr/$reason must not include renewal info";
@@ -96,6 +99,9 @@ sub ValidateSubmission {
   }
   elsif ($note && !$category) {
     push @errs, 'must include a category if there is a note';
+  }
+  if ($category && $category eq 'Not Government' && $attr ne 'und') {
+    push @errs, 'Not Government category requires und/NFI';
   }
   return join ', ', @errs;
 }

--- a/cgi/Project/SBCR.pm
+++ b/cgi/Project/SBCR.pm
@@ -111,21 +111,15 @@ sub ExtractReviewData {
   my $self = shift;
   my $cgi  = shift;
 
-  my $renNum = $cgi->param('renNum') || '';
-  my $renDate = $cgi->param('renDate') || '';
-  my $date = $cgi->param('date') || '';
-  my $pub = $cgi->param('pub') || '';
-  my $crown = $cgi->param('crown') || '';
-  my $actual = $cgi->param('actual') || '';
-  my $approximate = $cgi->param('approximate') || '';
+  my $params = $self->extract_parameters($cgi);
   my $data = {};
-  $data->{'renNum'} = $renNum if $renNum;
-  $data->{'renDate'} = $renDate if $renDate;
-  $data->{'date'} = $date if $cgi->param('date');
-  $data->{'pub'} = 1 if $cgi->param('pub');
-  $data->{'crown'} = 1 if $cgi->param('crown');
-  $data->{'actual'} = $actual if $actual;
-  $data->{'approximate'} = 1 if $approximate;
+  $data->{'renNum'} = $params->{renNum} if $params->{renNum};
+  $data->{'renDate'} = $params->{renDate} if $params->{renDate};
+  $data->{'date'} = $params->{date} if $params->{date};
+  $data->{'pub'} = 1 if $params->{pub};
+  $data->{'crown'} = 1 if $params->{crown};
+  $data->{'actual'} = $params->{actual} if $params->{actual};
+  $data->{'approximate'} = 1 if $params->{approximate};
   return $data;
 }
 

--- a/cgi/Project/SBCR.pm
+++ b/cgi/Project/SBCR.pm
@@ -4,6 +4,9 @@ use parent 'Project';
 use strict;
 use warnings;
 
+use lib $ENV{'SDRROOT'} . '/crms/lib';
+use CRMS::Entitlements;
+
 sub new {
   my $class = shift;
   return $class->SUPER::new(@_);

--- a/cgi/Project/SBCR.pm
+++ b/cgi/Project/SBCR.pm
@@ -106,7 +106,7 @@ sub ReviewPartials {
   return [
     'top',
     'bibdata_sbcr',
-    'expertDetails',
+    'expertDetails_sbcr',
     'authorities',
     'sbcr_form'
   ];

--- a/cgi/Project/SBCR.pm
+++ b/cgi/Project/SBCR.pm
@@ -10,15 +10,96 @@ sub new {
 }
 
 # ========== REVIEW ========== #
-# TODO
+# There must be a rights selection
+# 
 sub ValidateSubmission {
   my $self = shift;
   my $cgi  = shift;
 
+  my @errs;
   my $rights = $cgi->param('rights');
-  return if $rights;
-  return 'You must select a rights/reason combination';
+  return 'You must select a rights/reason combination' unless $rights;
+  my ($attr, $reason) = $self->{'crms'}->TranslateAttrReasonFromCode($rights);
+  # Renewal information
+  my $renNum = $cgi->param('renNum');
+  my $renDate = $cgi->param('renDate');
+  # ADD and pub date
+  my $date = $cgi->param('date');
+  my $pub = $cgi->param('pub');
+  my $crown = $cgi->param('crown');
+  my $actual = $cgi->param('actual');
+  #my $approximate = $cgi->param('approximate');
+  my $note = $cgi->param('note');
+  my $category = $cgi->param('category');
+  $date =~ s/\s+//g if $date;
+  $actual =~ s/\s+//g if $actual;
+  if ($date && $date !~ m/^-?\d{1,4}$/) {
+    push @errs, 'year must be only decimal digits';
+  }
+  elsif (($reason eq 'add' || $reason eq 'exp') && !$date) {
+    push @errs, "*/$reason must include a numeric year";
+  }
+  ## ic/ren requires a nonexpired renewal if 1963 or earlier
+  if ($attr eq 'ic' && $reason eq 'ren') {
+    if ($renNum && $renDate) {
+      # Blow away everything but the trailing 2 year digits.
+      $renDate =~ s,.*[A-Za-z](.*),$1,;
+      $renDate = '19'. $renDate;
+      if ($renDate < 1950 && $renDate != 19) {
+        push @errs, "renewal ($renDate) has expired: volume is pd";
+      }
+    }
+    else {
+      push @errs, 'ic/ren must include renewal id and renewal date';
+    }
+  }
+  ## pd/ren should not have a ren number or date, and is not allowed for post-1963 works.
+  if ($attr eq 'pd' && $reason eq 'ren') {
+    if ($renNum && $renDate) {
+      push @errs, 'pd/ren should not include renewal info';
+    }
+  }
+  ## pd*/cdpp must not have a ren number
+  if (($attr eq 'pd' || $attr eq 'pdus') && $reason eq 'cdpp' && ($renNum || $renDate)) {
+    push @errs, "$attr/$reason must not include renewal info";
+  }
+  if ($attr eq 'pd' && $reason eq 'cdpp' && (!$note || !$category)) {
+    push @errs, 'pd/cdpp must include note category and note text';
+  }
+  ## ic/cdpp requires a ren number
+  if ($attr eq 'ic' && $reason eq 'cdpp' && ($renNum || $renDate)) {
+    push @errs, 'ic/cdpp should not include renewal info';
+  }
+  if ($attr eq 'ic' && $reason eq 'cdpp' && (!$note || !$category)) {
+    push @errs, 'ic/cdpp must include note category and note text';
+  }
+  if ($attr eq 'und' && $reason eq 'nfi' && !$category) {
+    push @errs, 'und/nfi must include note category';
+  }
+  ## und/ren must have Note Category Inserts/No Renewal
+  if ($attr eq 'und' && $reason eq 'ren') {
+    if ($category ne 'Inserts/No Renewal') {
+      push @errs, 'und/ren must have note category Inserts/No Renewal';
+    }
+  }
+  ## and vice versa
+  if ($category eq 'Inserts/No Renewal') {
+    if ($attr ne 'und' || $reason ne 'ren') {
+      push @errs, 'Inserts/No Renewal must have rights code und/ren. ';
+    }
+  }
+  # Category/Note
+  if ($category && !$note) {
+    if ($self->{'crms'}->SimpleSqlGet('SELECT need_note FROM categories WHERE name=?', $category)) {
+      push @errs, qq{category "$category" requires a note};
+    }
+  }
+  elsif ($note && !$category) {
+    push @errs, 'must include a category if there is a note';
+  }
+  return join ', ', @errs;
 }
+
 
 # Extract Project-specific data from the CGI into a struct
 # that will be encoded as JSON string in the reviewdata table.
@@ -28,17 +109,63 @@ sub ExtractReviewData {
 
   my $renNum = $cgi->param('renNum') || '';
   my $renDate = $cgi->param('renDate') || '';
-  my $actualPubDate = $cgi->param('actualPubDate') || '';
+  my $date = $cgi->param('date') || '';
+  my $pub = $cgi->param('pub') || '';
+  my $crown = $cgi->param('crown') || '';
+  my $actual = $cgi->param('actual') || '';
+  my $approximate = $cgi->param('approximate') || '';
   my $data = {};
   $data->{'renNum'} = $renNum if $renNum;
   $data->{'renDate'} = $renDate if $renDate;
-  $data->{'actualPubDate'} = $actualPubDate if $actualPubDate;
+  $data->{'date'} = $date if $cgi->param('date');
+  $data->{'pub'} = 1 if $cgi->param('pub');
+  $data->{'crown'} = 1 if $cgi->param('crown');
+  $data->{'actual'} = $actual if $actual;
+  $data->{'approximate'} = 1 if $approximate;
   return $data;
 }
 
+sub FormatReviewData {
+  my $self = shift;
+  my $id   = shift;
+  my $json = shift;
+
+  my $jsonxs = JSON::XS->new->utf8->canonical(1)->pretty(0);
+  my $data = $jsonxs->decode($json);
+  my @lines;
+  if (scalar keys %$data) {
+    if ($data->{renNum} || $data->{renDate}) {
+      push @lines, sprintf '<strong>Renewal</strong> %s / %s', $data->{'renNum'}, $data->{'renDate'};
+    }
+    if ($data->{date}) {
+      my $date_type = ($data->{pub})? 'Pub' : 'ADD';
+      push @lines, "<strong>$date_type</strong> $data->{date}";
+    }
+    if ($data->{crown}) {
+      push @lines, "<strong>Crown</strong> \x{1F451}";
+    }
+    if ($data->{actual}) {
+      push @lines, "<strong>Actual Pub Date</strong> $data->{actual}";
+    }
+    if ($data->{approximate}) {
+      push @lines, "<strong>Approximate Pub Date</strong>";
+    }
+  }
+  return {
+    'id' => $id,
+    'format' => join('<br/>', @lines),
+    'format_long' => ''
+  };
+}
+
 sub ReviewPartials {
-  return ['top', 'bibdata_sbcr', 'authorities',
-          'sbcr_form', 'expertDetails'];
+  return [
+    'top',
+    'bibdata_sbcr',
+    'expertDetails',
+    'authorities',
+    'sbcr_form'
+  ];
 }
 
 1;

--- a/cgi/Project/SBCR.pm
+++ b/cgi/Project/SBCR.pm
@@ -20,6 +20,7 @@ sub ValidateSubmission {
   my $rights_data = CRMS::Entitlements->new(crms => $self->{crms})->rights_by_id($params->{rights});
   my $attr = $rights_data->{attribute_name};
   my $reason = $rights_data->{reason_name};
+  my $rights = $rights_data->{name};
   # Renewal information
   my $renNum = $params->{renNum};
   my $renDate = $params->{renDate};
@@ -30,13 +31,13 @@ sub ValidateSubmission {
   my $note = $params->{note};
   my $category = $params->{category};
   if ($date && $date !~ m/^-?\d{1,4}$/) {
-    push @errs, 'year must be only decimal digits';
+    push @errs, 'date must be only decimal digits';
   }
-  elsif (($reason eq 'add' || $reason eq 'exp') && !$date) {
+  if (($reason eq 'add' || $reason eq 'exp') && !$date) {
     push @errs, "*/$reason must include a numeric year";
   }
   ## ic/ren requires a nonexpired renewal if 1963 or earlier
-  if ($attr eq 'ic' && $reason eq 'ren') {
+  if ($rights eq 'ic/ren') {
     if ($renNum && $renDate) {
       my $year = $self->renewal_date_to_year($renDate);
       if ($year && $year < 1950) {
@@ -48,8 +49,8 @@ sub ValidateSubmission {
     }
   }
   ## pd/ren should not have a ren number or date, and is not allowed for post-1963 works.
-  if ($attr eq 'pd' && $reason eq 'ren') {
-    if ($renNum && $renDate) {
+  if ($rights eq 'pd/ren') {
+    if ($renNum || $renDate) {
       push @errs, 'pd/ren should not include renewal info';
     }
   }
@@ -57,36 +58,33 @@ sub ValidateSubmission {
     push @errs, 'Actual Publication Date must be a date or a date range (YYYY or YYYY-YYYY)';
   }
   ## pd*/cdpp must not have renewal data
-  if (($attr eq 'pd' || $attr eq 'pdus') && $reason eq 'cdpp' && ($renNum || $renDate)) {
-    push @errs, "$attr/$reason must not include renewal info";
+  if (($rights eq 'pd/cdpp' || $rights eq 'pdus/cdpp') && ($renNum || $renDate)) {
+    push @errs, "$attr/cdpp must not include renewal info";
   }
-  if ($attr eq 'pd' && $reason eq 'cdpp' && (!$note || !$category)) {
+  if ($rights eq 'pd/cdpp' && (!$note || !$category)) {
     push @errs, 'pd/cdpp must include note category and note text';
   }
   ## ic/cdpp must not have renewal data
   # NOTE: this could be merged with the pd/cdpp and pdus/cdpp logic above
-  if ($attr eq 'ic' && $reason eq 'cdpp' && ($renNum || $renDate)) {
+  if ($rights eq 'ic/cdpp' && ($renNum || $renDate)) {
     push @errs, 'ic/cdpp must not include renewal info';
   }
   # NOTE: this could be merged with the pd/cdpp and pdus/cdpp logic above
-  if ($attr eq 'ic' && $reason eq 'cdpp' && (!$note || !$category)) {
+  if ($rights eq 'ic/cdpp' && (!$note || !$category)) {
     push @errs, 'ic/cdpp must include note category and note text';
   }
-  if ($attr eq 'und' && $reason eq 'nfi' && !$category) {
+  if ($rights eq 'und/nfi' && !$category) {
     push @errs, 'und/nfi must include note category';
   }
-  
-  ### FIXME: STILL NEED TESTS FOR MOST OF THESE
-  
   ## und/ren must have Note Category Inserts/No Renewal
-  if ($attr eq 'und' && $reason eq 'ren') {
-    if (!defined $category || $category ne 'Inserts/No Renewal') {
+  if ($rights eq 'und/ren') {
+    if (!$category || $category ne 'Inserts/No Renewal') {
       push @errs, 'und/ren must have note category Inserts/No Renewal';
     }
   }
   ## and vice versa
   if ($category && $category eq 'Inserts/No Renewal') {
-    if ($attr ne 'und' || $reason ne 'ren') {
+    if ($rights ne 'und/ren') {
       push @errs, 'Inserts/No Renewal must have rights code und/ren. ';
     }
   }
@@ -132,23 +130,22 @@ sub FormatReviewData {
   my $jsonxs = JSON::XS->new->utf8->canonical(1)->pretty(0);
   my $data = $jsonxs->decode($json);
   my @lines;
-  if (scalar keys %$data) {
-    if ($data->{renNum} || $data->{renDate}) {
-      push @lines, sprintf '<strong>Renewal</strong> %s / %s', $data->{'renNum'}, $data->{'renDate'};
-    }
-    if ($data->{date}) {
-      my $date_type = ($data->{pub})? 'Pub' : 'ADD';
-      push @lines, "<strong>$date_type</strong> $data->{date}";
-    }
-    if ($data->{crown}) {
-      push @lines, "<strong>Crown</strong> \x{1F451}";
-    }
-    if ($data->{actual}) {
-      push @lines, "<strong>Actual Pub Date</strong> $data->{actual}";
-    }
-    if ($data->{approximate}) {
-      push @lines, "<strong>Approximate Pub Date</strong>";
-    }
+  my $renewal_fmt = $self->format_renewal_data($data->{renNum}, $data->{renDate});
+  if ($renewal_fmt) {
+    push @lines, $renewal_fmt;
+  }
+  if ($data->{date}) {
+    my $date_type = ($data->{pub})? 'Pub' : 'ADD';
+    push @lines, "<strong>$date_type</strong> $data->{date}";
+  }
+  if ($data->{crown}) {
+    push @lines, "<strong>Crown</strong> \x{1F451}";
+  }
+  if ($data->{actual}) {
+    push @lines, "<strong>Actual Pub Date</strong> $data->{actual}";
+  }
+  if ($data->{approximate}) {
+    push @lines, "<strong>Approximate Pub Date</strong>";
   }
   return {
     'id' => $id,
@@ -171,6 +168,9 @@ sub ReviewPartials {
 # values are stripped
 # Note: this might be useful to apply much earlier in the call chain, would
 # decouple project modules from CGI
+# Would have to think carefully about other possible side effect data transformations,
+# don't know if it's appropriate to delve into the semantics of the review
+# parameters too deeply.
 sub extract_parameters {
   my $self = shift;
   my $cgi  = shift;
@@ -185,6 +185,7 @@ sub extract_parameters {
 }
 
 # Turn a Stanford renewal date, e.g., 21Oct52, into a year, e.g., 1952
+# Note: this can also be used by the Core project logic in Project.pm
 sub renewal_date_to_year {
   my $self    = shift;
   my $renDate = shift;
@@ -192,6 +193,15 @@ sub renewal_date_to_year {
   # If the last two digits are not numeric for some reason then there is no reasonable answer.
   return '' unless $renDate =~ m/\d\d$/;
   return '19' . substr($renDate, -2, 2);
+}
+
+sub format_renewal_data {
+  my $self    = shift;
+  my $renNum  = shift || '';
+  my $renDate = shift || '';
+
+  return '' unless $renNum || $renDate;
+  return "<strong>Renewal</strong> $renNum / $renDate";
 }
 
 1;

--- a/cgi/partial/bibdata_sbcr.tt
+++ b/cgi/partial/bibdata_sbcr.tt
@@ -1,0 +1,21 @@
+<div class="reviewPartial">
+  <table>
+    <tr><td><strong>ID:</strong> [% htid %]</td></tr>
+    <tr>
+      <td><strong>Pub Date:</strong>
+        <span id="pub-date-span"
+          [% IF data.bibdata.extracted_dates.size != 1 %]class="red"[% END %]>
+          [% data.bibdata.display_date || '(unknown)' %]
+        </span>
+      </td>
+    </tr>
+    <tr><td><strong>Country:</strong> [% data.bibdata.country %]</td></tr>
+    <tr><td><strong>Current Rights:</strong> [% crms.CurrentRightsString(htid) || 'unknown' %]</td></tr>
+    [% projs = crms.GetUserProjects() %]
+    [% IF projs.size > 1 %]
+    <tr><td class="nowrap">
+      <strong>Project:</strong> [% data.project.name %]
+    </td></tr>
+    [% END %]
+  </table>
+</div>

--- a/cgi/partial/copyrightForm.tt
+++ b/cgi/partial/copyrightForm.tt
@@ -74,13 +74,7 @@
     <table>
     <tr style="height:20px;">
       <td><strong>Rights/Reason:</strong></td>
-      <td>
-      [% IF !ren %]
-        <img id="predictionLoader" width="16" height="16"
-             src="[% crms.WebPath('web', 'ajax-loader.gif') %]"
-             alt="loading..." style="display:none;"/>
-      [% END %]
-      </td>
+      <td></td>
     </tr>
     [% WHILE n < of %]
       <tr>

--- a/cgi/partial/expertDetails_sbcr.tt
+++ b/cgi/partial/expertDetails_sbcr.tt
@@ -1,0 +1,51 @@
+[% # Note: this should be merged with expertDetails.tt when we have a way to pass %]
+[% # per-partial config from a project's ReviewPartials implementation %]
+[% # and then it's just a matter of returning e.g. {file => 'expertDetails', config => {expert_only => 0}} %]
+<div class="reviewPartial">
+  <table class="nav">
+  [% IF status == 3 %]
+    <tr><td><span style="font-size:1.1em;color:red;">Provisional Match</span></td></tr>
+  [% ELSIF status == 2 %]
+    <tr><td><span style="font-size:1.1em;color:red;">Conflict</span></td></tr>
+  [% END %]
+  <tr><td><span style="font-size:1.1em">
+    [% IF crms.IsVolumeInQueue(htid) %]
+      Priority [% crms.GetPriority(htid) %]
+    [% ELSE %]
+      Not in queue. Please cancel; you will get an error if you submit.
+    [% END %]
+  </span></td></tr>
+  [% totalReviews = crms.GetReviewCount(htid, 1) %]
+  [% IF totalReviews > 0 %]
+    <tr><td><a class="smallishText"
+               href="[% crms.WebPath('cgi', 'crms?p=adminHistoricalReviews;search1=Identifier;search1value=' _ htid) %]"
+               target="_blank">
+    [% totalReviews %] historical [% crms.Pluralize("review", totalReviews) %]
+    </a></td></tr>
+    <tr><td>
+      <span class="smallishText" style="color:green;">
+        Current rights [% crms.GetCurrentRights(htid) %]
+      </span>
+    </td></tr>
+  [% END %]
+  [% totalReviews = crms.GetReviewCount(htid) %]
+  [% IF totalReviews > 0 %]
+    <tr><td><a class="smallishText"
+               href="[% crms.WebPath('cgi', 'crms?p=adminReviews;search1=Identifier;search1value=' _ htid) %]"
+               target="_blank">
+    [% totalReviews %] active [% crms.Pluralize("review", totalReviews) %]
+    </a></td></tr>
+  [% END %]
+  [% IF info.addedby %]
+    <tr><td><span class="smallishText">Added by [% info.addedby %]</span></td></tr>
+  [% END %]
+  [% status = crms.GetSystemStatus() %]
+  [% IF status.2 %]
+    <tr>
+      <td style="align:left;">
+        <span style="font-size:1.3em;font-weight:bold;color:#990000;">[% status.2 %]</span>
+      </td>
+    </tr>
+  [% END %]
+  </table>
+</div>

--- a/cgi/partial/import_user.tt
+++ b/cgi/partial/import_user.tt
@@ -1,0 +1,32 @@
+[% # When an expert is adjudicating a conflict, make it possible to import user-entered data %]
+[% # rather than manually entering it (though there is that option if expert needs to add or modify %]
+
+[% IF expert && importUser %]
+  [% reviews = data.reviews %]
+  [% IF reviews.keys.size %]
+    <table>
+      <tr>
+        <td>
+          <div style="line-height:20px;">
+            <strong>Import user review:</strong>
+          </div>
+        </td>
+        <td>
+          [% # Note there is no JS that actually causes this image to be displayed %]
+          [% # Since importing user review data is just a matter of swapping in local JSON data %]
+          [% # It would probably be safe to remove this %]
+          <img id="importLoader" src="[% crms.WebPath('web', 'ajax-loader.gif') %]"
+               alt="loading..." style="display:none;"/>
+        </td>
+      [% FOREACH user IN reviews.keys.sort %]
+        <tr>
+          <td><label for="pull[% user %]">[% user %] ([% reviews.$user.attr %]/[% reviews.$user.reason %])</label></td>
+          <td><input type="radio" name="pullrights" id="pull[% user %]"
+                     [% IF importUser == user %]checked="checked"[% END %]
+                     onclick="insertUserReviewData('[% user %]');"/>
+          </td>
+        </tr>
+      [% END %]
+    </table>
+  [% END %]
+[% END %]

--- a/cgi/partial/notes.tt
+++ b/cgi/partial/notes.tt
@@ -1,0 +1,12 @@
+<div id="note-container" class="note-container">
+  <strong><label for="category-menu">Notes: </label></strong>
+  <select id="category-menu" class="review" name="category">
+    <option value="" [% (NOT u_category)? 'selected="selected"':'' %]>none</option>
+    [% FOREACH cat IN crms.Categories(htid) %]
+      <option value="[% cat %]" [% (cat == u_category)? 'selected="selected"':'' %]>[% cat %]</option>
+    [% END %]
+  </select>
+  <textarea title="Note Text" id="note-textarea" name="note" cols="20" rows="1">[% u_note %]</textarea>
+  <a style="position:absolute;left:-999px;" href="#" accesskey="n"
+     onfocus="document.getElementById('NoteTextField').focus()">.</a>
+</div>

--- a/cgi/partial/rights.tt
+++ b/cgi/partial/rights.tt
@@ -1,4 +1,8 @@
 
+[% # Note: before trying to use this with projects other than SBCR, need to add a prediction loader in the <td> after Rights/Reason %]
+[% # and modify the JS togglePredictionLoader() routine to take an id parameter. %]
+[% # SBCR has a prediction loader for the renDate so we need to trigger a loader by id instead of %]
+[% # assuming there will only be one loader per operational pane, and its id will be "predictionLoader" %]
 [% rights = crms.Rights(htid, 1) %]
 <div id="RightsReason" style="position:relative;">
   <div id="rightsHelp" style="position:absolute;top:0px;right:1em;">

--- a/cgi/partial/rights.tt
+++ b/cgi/partial/rights.tt
@@ -11,42 +11,45 @@
       <span>
       [% # This is an experimental version of the "rights reference" tooltip which uses %]
       [% # attr/reason descriptions from ht_rights rather than our own, which are not well %]
-      [% # maintained and contain many blanks. Do we need specialized CRMS rights descriptions? %]
+      [% # maintained and contain many blanks. %]
+      [% # KH says: we do not need specialized CRMS rights descriptions. %]
+      [% # When projects other than SBCR begin to use this, the `description` column from %]
+      [% # the `crms.rights` table can be removed %]
       [% FOR right IN rights %]
         <strong>[% right.rights %]</strong> - [% right.attr_dscr %] / [% right.reason_dscr %]<br/>
       [% END %]
       </span>
     </a>
   </div>
-  [% rights = crms.Rights(htid) %]
-  [% of = rights.size() %]
-  [% n = 0 %]
-    <table>
+  [% # TODO: the rights structure is needed by every project. %]
+  [% # We should provide it to the templates and let them derive layouts as needed %]
+  [% # e.g., convert to two columns, convert to pairs, via utility routines %]
+  [% rights = crms.array_to_pairs(crms.Rights(htid)) %]
+  <table>
     <tr>
       <td><strong>Rights/Reason:</strong></td>
       <td></td>
     </tr>
-    [% WHILE n < of %]
+    [% FOREACH rights_pair IN rights %]
       <tr>
-      [% right = rights.$n %]
-      <td style="width:50%;">
-        <input type="radio" id="[% 'r' _ right.id %]" name="rights" value="[% right.id %]"
-              [% IF right.n < 10 %]accesskey="[% right.n %]"[% END %]
-              [% IF u_rights == right.id %] checked="checked"[% END %]/>
-        <label for="[% 'r' _ right.id %]">[% right.attr %]/[% right.reason.upper %] ([% right.n %])</label>
-      </td>
-      [% n = n + 1 %]
-      <td style="width:50%;">
-        [% IF n < of %]
-        [% right = rights.$n %]
-        <input type="radio" id="[% 'r' _ right.id %]" name="rights" value="[% right.id %]"
-              [% IF right.n < 10 %]accesskey="[% right.n %]"[% END %]
-              [% IF u_rights == right.id %] checked="checked"[% END %]/>
-        <label for="[% 'r' _ right.id %]">[% right.attr %]/[% right.reason.upper %] ([% right.n %])</label>
-        [% END %]
-      </td>
+        [% right = rights_pair.0 %]
+        <td style="width:50%;">
+          <input type="radio" id="[% 'r' _ right.id %]" name="rights" value="[% right.id %]"
+                [% IF right.n < 10 %]accesskey="[% right.n %]"[% END %]
+                [% IF u_rights == right.id %] checked="checked"[% END %]/>
+          <label for="[% 'r' _ right.id %]">[% right.attr %]/[% right.reason.upper %] ([% right.n %])</label>
+        </td>
+
+        <td style="width:50%;">
+          [% right = rights_pair.1 %]
+          [% IF right %]
+            <input type="radio" id="[% 'r' _ right.id %]" name="rights" value="[% right.id %]"
+                  [% IF right.n < 10 %]accesskey="[% right.n %]"[% END %]
+                  [% IF u_rights == right.id %] checked="checked"[% END %]/>
+            <label for="[% 'r' _ right.id %]">[% right.attr %]/[% right.reason.upper %] ([% right.n %])</label>
+          [% END %]
+        </td>
       </tr>
-      [% n = n + 1 %]
     [% END %]
   </table>
 </div>

--- a/cgi/partial/rights.tt
+++ b/cgi/partial/rights.tt
@@ -9,13 +9,11 @@
     <a class="tip" href="#">
       <img width="16" height="16" alt="Rights/Reason Help" src="[% crms.WebPath('web', 'help.png') %]"/>
       <span>
-      [% asterisk = 0 %]
+      [% # This is an experimental version of the "rights reference" tooltip which uses %]
+      [% # attr/reason descriptions from ht_rights rather than our own, which are not well %]
+      [% # maintained and contain many blanks. Do we need specialized CRMS rights descriptions? %]
       [% FOR right IN rights %]
-        <strong>[% right.rights %]</strong> - [% right.description %]<br/>
-        [% IF right.description.search('\*') %][% asterisk = 1 %][% END %]
-      [% END %]
-      [% IF asterisk %]
-        <br/>* if no publication date listed on piece, use copyright date
+        <strong>[% right.rights %]</strong> - [% right.attr_dscr %] / [% right.reason_dscr %]<br/>
       [% END %]
       </span>
     </a>

--- a/cgi/partial/rights.tt
+++ b/cgi/partial/rights.tt
@@ -1,0 +1,51 @@
+
+[% rights = crms.Rights(htid, 1) %]
+<div id="RightsReason" style="position:relative;">
+  <div id="rightsHelp" style="position:absolute;top:0px;right:1em;">
+    <a class="tip" href="#">
+      <img width="16" height="16" alt="Rights/Reason Help" src="[% crms.WebPath('web', 'help.png') %]"/>
+      <span>
+      [% asterisk = 0 %]
+      [% FOR right IN rights %]
+        <strong>[% right.rights %]</strong> - [% right.description %]<br/>
+        [% IF right.description.search('\*') %][% asterisk = 1 %][% END %]
+      [% END %]
+      [% IF asterisk %]
+        <br/>* if no publication date listed on piece, use copyright date
+      [% END %]
+      </span>
+    </a>
+  </div>
+  [% rights = crms.Rights(htid) %]
+  [% of = rights.size() %]
+  [% n = 0 %]
+    <table>
+    <tr>
+      <td><strong>Rights/Reason:</strong></td>
+      <td></td>
+    </tr>
+    [% WHILE n < of %]
+      <tr>
+      [% right = rights.$n %]
+      <td style="width:50%;">
+        <input type="radio" id="[% 'r' _ right.id %]" name="rights" value="[% right.id %]"
+              [% IF right.n < 10 %]accesskey="[% right.n %]"[% END %]
+              [% IF u_rights == right.id %] checked="checked"[% END %]/>
+        <label for="[% 'r' _ right.id %]">[% right.attr %]/[% right.reason.upper %] ([% right.n %])</label>
+      </td>
+      [% n = n + 1 %]
+      <td style="width:50%;">
+        [% IF n < of %]
+        [% right = rights.$n %]
+        <input type="radio" id="[% 'r' _ right.id %]" name="rights" value="[% right.id %]"
+              [% IF right.n < 10 %]accesskey="[% right.n %]"[% END %]
+              [% IF u_rights == right.id %] checked="checked"[% END %]/>
+        <label for="[% 'r' _ right.id %]">[% right.attr %]/[% right.reason.upper %] ([% right.n %])</label>
+        [% END %]
+      </td>
+      </tr>
+      [% n = n + 1 %]
+    [% END %]
+  </table>
+</div>
+

--- a/cgi/partial/sbcr_form.tt
+++ b/cgi/partial/sbcr_form.tt
@@ -123,19 +123,8 @@
 
 <div id="RightsCont" class="subpartial">
   [% INCLUDE partial/rights.tt %]
+  [% INCLUDE partial/notes.tt %]
 
-<div id="Notes">
-  <strong><label for="catMenu">Notes: </label></strong>
-  <select id="catMenu" class="review" name="category">
-    <option value="" [% (NOT u_category)? 'selected="selected"':'' %]>none</option>
-    [% FOREACH cat IN crms.Categories(htid) %]
-      <option value="[% cat %]" [% (cat == u_category)? 'selected="selected"':'' %]>[% cat %]</option>
-    [% END %]
-  </select>
-  <textarea title="Note Text" id="note-textarea" name="note" cols="20" rows="1">[% u_note %]</textarea>
-  <a style="position:absolute;left:-999px;" href="#" accesskey="n"
-     onfocus="document.getElementById('NoteTextField').focus()">.</a>
-</div>
 <div id="SubmitForm">
   <table>
     <tr>

--- a/cgi/partial/sbcr_form.tt
+++ b/cgi/partial/sbcr_form.tt
@@ -37,7 +37,7 @@
 
     <tr>
       <td class="nowrap">
-        <label id="renewalFieldLabel" for="renewalField" style="display:inline-block;">
+        <label id="renewalFieldLabel" for="renewal-number-field" style="display:inline-block;">
           <strong>Renewal&nbsp;ID:</strong>
           <img id="predictionLoader" width="12" height="12"
                    src="[% crms.WebPath('web', 'ajax-loader.gif') %]"
@@ -45,7 +45,7 @@
         </label>
       </td>
       <td class="nowrap">
-        <input id="renewalField" title="[% label %]" type="text" name="renNum"
+        <input id="renewal-number-field" title="[% label %]" type="text" name="renNum"
                value="[% u_renNum %]" size="8"
                onblur="getRenewalDate(0)"/>
       </td>
@@ -113,8 +113,7 @@
     </tr>
     <tr>
       <td colspan="2" class="reviewGrey">
-        <input type="checkbox" id="approximate-checkbox" name="approximate"[% (u_approximate)? ' checked="checked"':'' %]
-               onchange="checkboxSelectionChanged(this.id);"/>
+        <input type="checkbox" id="approximate-checkbox" name="approximate"[% (u_approximate)? ' checked="checked"':'' %]/>
         <label for="approximate-checkbox">&nbsp;Pub&nbsp;Date&nbsp;is&nbsp;Approximate</label>
       </td>
     </tr>
@@ -198,7 +197,7 @@
             <td><label for="pull[% user %]">[% user %] ([% reviews.$user.attr %]/[% reviews.$user.reason %])</label></td>
             <td><input type="radio" name="pullrights" id="pull[% user %]"
                        [% IF importUser == user %]checked="checked"[% END %]
-                       onclick="popReviewInfo('[% user %]');"/>
+                       onclick="insertUserReviewData('[% user %]');"/>
             </td>
           </tr>
         [% END %]
@@ -211,28 +210,6 @@
 <script>
 var gReviewData = [% data.json %];
 addEvent(window, 'load', partial_sbcr_form_mainWindowLoad);
-
-function popReviewInfo(user)
-{
-  var review = gReviewData.reviews[user];
-  var button = document.getElementById("r" + review.rights);
-  if (button) { button.checked = "checked"; }
-  var renNum = null;
-  var renDate = null;
-  if (review.data)
-  {
-    renNum = review.data.renNum;
-    renDate = review.data.renDate;
-  }
-  var field = document.getElementById("renewalField");
-  if (field) { field.value = renNum; }
-  // FIXME: renewalFieldCheckbox should only appear in the Commonwealth UI, not here.
-  button = document.getElementById("renewalFieldCheckbox");
-  if (button) { button.checked = (renNum != null); }
-  document.submitReview.renDate.value = renDate;
-  document.submitReview.note.value = review.note;
-  selMenuItem('catMenu', (review.category)? review.category:'');
-}
 
 function partial_sbcr_form_mainWindowLoad(e) {
   [% IF importUser %]
@@ -254,14 +231,14 @@ function partial_sbcr_form_mainWindowLoad(e) {
 function insertUserReviewData(user) {
   var review = gReviewData.reviews[user];
   // Renewal
-  var field = document.getElementById("renNum");
+  var field = document.getElementById("renewal-number-field");
   if (field) { field.value = review.data?.renNum || ''; }
-  field = document.getElementById("renDate");
+  field = document.getElementById("renewal-date-field");
   if (field) { field.value = review.data?.renDate || ''; }
   // ADD/Pub
   field = document.getElementById("add-field");
   if (field) { field.value = review.data?.date || ''; }
-  var field = document.getElementById("actual-pub-date-field");
+  field = document.getElementById("actual-pub-date-field");
   if (field) { field.value = review.data?.actual || ""; }
   button = document.getElementById("pub-checkbox");
   if (button) { button.checked = Boolean(review.data?.pub); }
@@ -331,7 +308,7 @@ function syncCheckboxes(checked, fromId, toId) {
 // but when tabbing out of the field force=0 so we don't clobber user-entered
 // values.
 async function getRenewalDate(force) {
-  var renNum = document.getElementById('renewalField');
+  var renNum = document.getElementById('renewal-number-field');
   var renDate = document.getElementById('renewal-date-field');
   if (renDate.value.length > 0 && !force) {
     return;

--- a/cgi/partial/sbcr_form.tt
+++ b/cgi/partial/sbcr_form.tt
@@ -1,0 +1,392 @@
+[% cgi        = crms.get('cgi')         %]
+[% importUser = cgi.param('importUser') %]
+
+[% # Set up values from CGI (in case of error) or existing review (editing). %]
+[% u_renNum = (error)? cgi.param('renNum') : data.reviews.$user.data.renNum %]
+[% u_renDate = (error)? cgi.param('renDate') : data.reviews.$user.data.renDate %]
+[% u_date = (error)? cgi.param('date') : data.reviews.$user.data.date %]
+[% u_pub = (error)? cgi.param('pub') : data.reviews.$user.data.pub %]
+[% u_crown = (error)? cgi.param('crown') : data.reviews.$user.data.crown %]
+[% u_actual = (error)? cgi.param('actual') : data.reviews.$user.data.actual %]
+[% u_rights = (error)? cgi.param('rights') : data.reviews.$user.rights %]
+[% u_category = (error)? cgi.param('category') : data.reviews.$user.category %]
+[% u_note = (error)? cgi.param('note') : data.reviews.$user.note %]
+[% u_swiss = (error)? cgi.param('swiss') : data.reviews.$user.swiss %]
+[% u_hold = (error)? cgi.param('hold') : data.reviews.$user.hold %]
+
+[% writing_hand_tag = "<img src='" _ crms.WebPath('web', 'img/writing-hand.svg') _ "' width='20' height='20' alt='writing hand'/>" %]
+[% author_death_date_text = "Author&nbsp;Death&nbsp;Date:&nbsp;" _ writing_hand_tag %]
+[% publication_date_text = "Publication&nbsp;Date:" %]
+
+<div class="reviewPartial">
+<form name="submitReview" action="crms">
+  <input type="hidden" name="p"       value="finishReview"/>
+  <input type="hidden" name="htid" value="[% htid %]"/>
+  <input type="hidden" name="start"   value="[% crms.GetNow() %]"/>
+  <input type="hidden" name="user"    value="[% user %]"/>
+  <input type="hidden" name="editing" value="[% editing %]"/>
+  <table>
+    [% viafwarn = crms.VIAFWarning(htid, data.record) %]
+    [% IF viafwarn %]
+      [% viafwarn = "Warning: possible foreign author: " _ viafwarn %]
+      <tr><td colspan="2"><span class="red"><strong>$viafwarn</strong></span></td></tr>
+    [% END %]
+
+    <!-- RENEWAL INFO -->
+
+    <tr>
+      <td class="nowrap">
+        <label id="renewalFieldLabel" for="renewalField" style="display:inline-block;">
+          <strong>Renewal&nbsp;ID:</strong>
+          <img id="predictionLoader" width="12" height="12"
+                   src="[% crms.WebPath('web', 'ajax-loader.gif') %]"
+                   alt="loading..." style="display:none;"/>
+        </label>
+      </td>
+      <td class="nowrap">
+        <input id="renewalField" title="[% label %]" type="text" name="renNum"
+               value="[% u_renNum %]" size="8"
+               onblur="getRenewalDate(0)"/>
+      </td>
+    </tr>
+    <tr>
+      <td class="reviewGrey nowrap" style="text-align:left;margin:0px;padding:0px;">
+        <button type="button" onclick="getRenewalDate(1);" id="get-renewal-date-button"
+                class="reviewblue" style="margin:0px;padding:1px;background-color:#d0dee6;">
+          Get Renewal Date
+        </button>
+      </td>
+      <td>
+        <input type="text" title="Stanford Renewal Date" id="renewal-date-field" name="renDate"
+               value="[% u_renDate %]" size="8"/>
+      </td>
+    </tr>
+
+    <!-- ADD/Pub Info -->
+
+    <tr>
+      [% label = (u_pub)? publication_date_text : author_death_date_text %]
+      <td class="nowrap">
+        <strong>
+          <label id="add-field-label" for="add-field">[% label %] </label>
+        </strong>
+      </td>
+      <td class="nowrap">
+        <input id="add-field" title="[% label %]" type="text" name="date"
+               value="[% u_date %]" size="6"/>
+      </td>
+    </tr>
+    <!-- ACTUAL PUB DATE -->
+    <!-- Only visible when pub is unchecked -->
+    [% display = "table-row" %]
+    [% IF u_pub %]
+      [% display = "none" %]
+    [% END %]
+    <tr id="actual-pub-date-row" style="display:[% display %];">
+      <td class="nowrap">
+        <strong>
+          <label for="actual-pub-date-field">Actual Pub Date:</label>
+        </strong>
+      </td>
+      <td class="nowrap">
+        <input id="actual-pub-date-field" title="Actual Pub Date" type="text" name="actual"
+               value="[% u_actual %]" size="6"/>
+      </td>
+    </tr>
+    
+    <tr>
+      <td class="reviewGrey">
+        <input type="checkbox" id="pub-checkbox" name="pub"[% (u_pub)? ' checked="checked"':'' %]
+               onchange="checkboxSelectionChanged(this.id);"/>
+        <label for="pub-checkbox">&nbsp;Pub Date</label>
+      </td>
+      <td>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2" class="reviewGrey">
+        <input type="checkbox" id="crown-checkbox" name="crown"[% (u_crown)? ' checked="checked"':'' %]
+               onchange="checkboxSelectionChanged(this.id);"/>
+        <label for="crown-checkbox">&nbsp;Crown&nbsp;Copyright</label>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2" class="reviewGrey">
+        <span id="rights-description"></span>
+      </td>
+    </tr>
+    
+  </table>
+[% rights = crms.Rights(htid, 1) %]
+<div id="RightsCont" class="subpartial">
+<div id="RightsReason" style="position:relative;">
+  <div id="rightsHelp" style="position:absolute;top:0px;right:1em;">
+    <a class="tip" href="#">
+      <img width="16" height="16" alt="Rights/Reason Help" src="[% crms.WebPath('web', 'help.png') %]"/>
+      <span>
+      [% asterisk = 0 %]
+      [% FOR right IN rights %]
+        <strong>[% right.rights %]</strong> - [% right.description %]<br/>
+        [% IF right.description.search('\*') %][% asterisk = 1 %][% END %]
+      [% END %]
+      [% IF asterisk %]
+        <br/>* if no publication date listed on piece, use copyright date
+      [% END %]
+      </span>
+    </a>
+  </div>
+  [% rights = crms.Rights(htid) %]
+  [% of = rights.size() %]
+  [% n = 0 %]
+    <table>
+    [% WHILE n < of %]
+      <tr>
+      [% right = rights.$n %]
+      <td style="width:50%;">
+        <input type="radio" id="[% 'r' _ right.id %]" name="rights" value="[% right.id %]"
+              [% IF right.n < 10 %]accesskey="[% right.n %]"[% END %]
+              [% IF u_rights == right.id %] checked="checked"[% END %]/>
+        <label for="[% 'r' _ right.id %]">[% right.attr %]/[% right.reason.upper %] ([% right.n %])</label>
+      </td>
+      [% n = n + 1 %]
+      <td style="width:50%;">
+        [% IF n < of %]
+        [% right = rights.$n %]
+        <input type="radio" id="[% 'r' _ right.id %]" name="rights" value="[% right.id %]"
+              [% IF right.n < 10 %]accesskey="[% right.n %]"[% END %]
+              [% IF u_rights == right.id %] checked="checked"[% END %]/>
+        <label for="[% 'r' _ right.id %]">[% right.attr %]/[% right.reason.upper %] ([% right.n %])</label>
+        [% END %]
+      </td>
+      </tr>
+      [% n = n + 1 %]
+    [% END %]
+    </table>
+</div>
+<div id="Notes">
+  <strong><label for="catMenu">Notes: </label></strong>
+  <select id="catMenu" class="review" name="category">
+    <option value="" [% (NOT u_category)? 'selected="selected"':'' %]>none</option>
+    [% FOREACH cat IN crms.Categories(htid) %]
+      <option value="[% cat %]" [% (cat == u_category)? 'selected="selected"':'' %]>[% cat %]</option>
+    [% END %]
+  </select>
+  <textarea title="Note Text" id="note-textarea" name="note" cols="20" rows="1">[% u_note %]</textarea>
+  <a style="position:absolute;left:-999px;" href="#" accesskey="n"
+     onfocus="document.getElementById('NoteTextField').focus()">.</a>
+</div>
+<div id="SubmitForm">
+  <table>
+    <tr>
+      <td><input class="review" type="submit" name="submit" value="Submit" accesskey="s"/></td>
+      <td style="padding-left:2em;"><input class="review" type="submit" name="submit"
+          value="Cancel" accesskey="c" onclick="this.form.onsubmit=null;"/></td>
+    </tr>
+  </table>
+  </div>
+  <table>
+  [% IF expert %]
+    <tr>
+      [% checked = (u_swiss || ((status == 2 || status == 3) && data.project.SwissByDefault())) %]
+      <td style="text-align:left;">
+        <input type="checkbox" id="swiss" name="swiss" [% (checked)? 'checked="checked"':'' %]/>
+      </td>
+      <td><label for="swiss">Do not invalidate other reviews<br/>for this volume</label></td>
+    </tr>
+  [% END %]
+  [% holds = crms.CountHolds() %]
+  [% IF !hold %]
+    [% hold = crms.HoldForItem(htid, user) %]
+  [% END %]
+    <tr>
+      <td style="text-align:left;">
+        <input type="checkbox" id="hold" name="hold"
+               [% (holds >=5 && !hold)? 'disabled="disabled"':'' %]
+               [% (hold)? 'checked="checked"':'' %]
+               onclick="toggleVisibility('expiry');"/>
+      </td>
+      <td><label for="hold">Hold for Question</label></td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <span class="smallishText" [% (holds >=5)? 'style="color:red;"':'' %]>
+            <!--Held reviews will remain unprocessed.-->
+            You currently have [% holds %] out of the maximum 5 volumes on hold.
+            <!--It is up to you to get in touch with an expert.-->
+        </span>
+      </td>
+    </tr>
+  </table>
+  [% IF expert && importUser %]
+    [% reviews = data.reviews %]
+    [% IF reviews.keys.size %]
+      <table>
+        <tr>
+          <td>
+            <div style="line-height:20px;">
+              <strong>Import user review:</strong>
+            </div>
+          </td>
+          <td>
+            <img id="importLoader" src="[% crms.WebPath('web', 'ajax-loader.gif') %]"
+                 alt="loading..." style="display:none;"/>
+          </td>
+        [% FOREACH user IN reviews.keys.sort %]
+          <tr>
+            <td><label for="pull[% user %]">[% user %] ([% reviews.$user.attr %]/[% reviews.$user.reason %])</label></td>
+            <td><input type="radio" name="pullrights" id="pull[% user %]"
+                       [% IF importUser == user %]checked="checked"[% END %]
+                       onclick="popReviewInfo('[% user %]');"/>
+            </td>
+          </tr>
+        [% END %]
+      </table>
+    [% END %]
+  [% END %]
+</div>
+</form>
+
+<script>
+var gReviewData = [% data.json %];
+addEvent(window, 'load', partial_sbcr_form_mainWindowLoad);
+
+function popReviewInfo(user)
+{
+  var review = gReviewData.reviews[user];
+  var button = document.getElementById("r" + review.rights);
+  if (button) { button.checked = "checked"; }
+  var renNum = null;
+  var renDate = null;
+  if (review.data)
+  {
+    renNum = review.data.renNum;
+    renDate = review.data.renDate;
+  }
+  var field = document.getElementById("renewalField");
+  if (field) { field.value = renNum; }
+  // FIXME: renewalFieldCheckbox should only appear in the Commonwealth UI, not here.
+  button = document.getElementById("renewalFieldCheckbox");
+  if (button) { button.checked = (renNum != null); }
+  document.submitReview.renDate.value = renDate;
+  document.submitReview.note.value = review.note;
+  selMenuItem('catMenu', (review.category)? review.category:'');
+}
+
+function partial_sbcr_form_mainWindowLoad(e) {
+  [% IF importUser %]
+    insertUserReviewData('[% importUser %]');
+  [% END %]
+  var addField = document.getElementById("add-field");
+  var year = addField.value;
+  var patt = /-?[0-9]+/;
+  if (patt.test(year)) {
+    document.getElementById("note-textarea").focus();
+  } else {
+    document.getElementById("add-field").focus();
+  }
+}
+
+// Insert the data entered by one user in a previous review,
+// into the interface of the expert adjudicating the conflict
+// or provisional match.
+function insertUserReviewData(user) {
+  var review = gReviewData.reviews[user];
+  var button = document.getElementById("r" + review.rights);
+  if (button) { button.checked = "checked"; }
+  button = document.getElementById("pub-checkbox");
+  if (button) { button.checked = Boolean(review.data?.pub); }
+  button = document.getElementById("crown-checkbox");
+  if (button) { button.checked = Boolean(review.data?.crown); }
+  var field = document.getElementById("add-field");
+  if (field) { field.value = review.data?.date || ''; }
+  var field = document.getElementById("actual-pub-date-field");
+  if (field) { field.value = review.data?.actual || ""; }
+  document.submitReview.note.value = review.note || "";
+  selMenuItem("category-menu", review.category || "");
+  toggleADD();
+}
+
+// Rewords the Commonwealth date entry based on whether "Pub Date" is checked.
+// Shows the Actual Pub Date field if "Pub Date" is checked and not single date
+function toggleADD() {
+  var label = document.getElementById("add-field-label");
+  var cb = document.getElementById("pub-checkbox");
+  var addField = document.getElementById("add-field");
+  label.innerHTML = (cb.checked) ? "[% publication_date_text %]" : "[% author_death_date_text %]";
+  addField.title = (cb.checked) ? "Publication Date" : "Author Death Date";
+  var actualPubDateRow = document.getElementById("actual-pub-date-row");
+  if (cb.checked) {
+    actualPubDateRow.style.display = "none";
+    // Transfer content of actual pub date to ADD if there is something there
+    var addField = document.getElementById("add-field");
+    var actualField = document.getElementById("actual-pub-date-field");
+    if (actualField.value.length > 0) {
+      addField.value = actualField.value;
+    }
+  } else {
+    actualPubDateRow.style.display = "table-row";
+  }
+}
+
+// Called whenever the user checks or unchecks the pub date or crown checkbox.
+// Synchronizes other checkbox to current selection,
+// synchronizes the date label with the pub date checkbox,
+// and refreshes the rights prediction.
+function checkboxSelectionChanged(id) {
+  if (id === 'pub-checkbox') {
+    syncCheckboxes(false, id, 'crown-checkbox');
+  } else {
+    syncCheckboxes(true, id, 'pub-checkbox');
+  }
+  toggleADD();
+}
+
+// Propagate checkedness across category/subcategory boundary.
+// Check pub date checkbox if crown checkbox is checked:
+// syncCheckedness(true, "crown-checkbox", "pub-checkbox");
+// Uncheck crown checkbox if pub date checkbox is unchecked
+// syncCheckedness(false, "pub-checkbox", "crown-checkbox");
+function syncCheckboxes(checked, fromId, toId) {
+  var fromElement = document.getElementById(fromId);
+  var toElement = document.getElementById(toId);
+  if (fromElement && toElement && fromElement.checked === checked) {
+    toElement.checked = fromElement.checked;
+  }
+}
+
+// This can replace popRenewalDate with the appropriate parameters
+// force param is set to 1 when the Get Renewal Date button is clicked
+// but when tabbing out of the field force=0 so we don't clobber user-entered
+// values.
+async function getRenewalDate(force) {
+  var renNum = document.getElementById('renewalField');
+  var renDate = document.getElementById('renewal-date-field');
+  if (renDate.value.length > 0 && !force) {
+    return;
+  }
+  var id  = renNum.value;
+  if (!id.length) {
+    return;
+  }
+  togglePredictionLoader(true);
+  var url = ajaxURL("getRenewalDate") + "?id=" + id
+  let response = await fetch(url);
+  if (response.status === 200) {
+    let data = await response.text();
+    displayRenewalDate(data);
+  }
+  togglePredictionLoader(false);
+}
+
+// Display JSON response from predictRights CGI in the Commonwealth UI
+function displayRenewalDate(data) {
+  var renDate = document.getElementById('renewal-date-field');
+  //console.log('AHOY displayRenewalDate with ' + data);
+  var renDateField = document.getElementById('renewal-date-field');
+  if (renDateField) {
+    renDateField.value = data;
+  }
+}
+</script>
+
+</div>

--- a/cgi/partial/sbcr_form.tt
+++ b/cgi/partial/sbcr_form.tt
@@ -167,32 +167,7 @@
       </td>
     </tr>
   </table>
-  [% IF expert && importUser %]
-    [% reviews = data.reviews %]
-    [% IF reviews.keys.size %]
-      <table>
-        <tr>
-          <td>
-            <div style="line-height:20px;">
-              <strong>Import user review:</strong>
-            </div>
-          </td>
-          <td>
-            <img id="importLoader" src="[% crms.WebPath('web', 'ajax-loader.gif') %]"
-                 alt="loading..." style="display:none;"/>
-          </td>
-        [% FOREACH user IN reviews.keys.sort %]
-          <tr>
-            <td><label for="pull[% user %]">[% user %] ([% reviews.$user.attr %]/[% reviews.$user.reason %])</label></td>
-            <td><input type="radio" name="pullrights" id="pull[% user %]"
-                       [% IF importUser == user %]checked="checked"[% END %]
-                       onclick="insertUserReviewData('[% user %]');"/>
-            </td>
-          </tr>
-        [% END %]
-      </table>
-    [% END %]
-  [% END %]
+  [% INCLUDE partial/import_user.tt %]
 </div>
 </form>
 

--- a/cgi/partial/sbcr_form.tt
+++ b/cgi/partial/sbcr_form.tt
@@ -173,6 +173,9 @@
 
 <script>
 var gReviewData = [% data.json %];
+// Save contents of ADD entry when Pub is selected and Actual Pub Date is swapped in.
+// Restore from this value if Pub is deselected.
+var gSavedADD = '';
 addEvent(window, 'load', partial_sbcr_form_mainWindowLoad);
 
 function partial_sbcr_form_mainWindowLoad(e) {
@@ -231,7 +234,6 @@ function toggleADD() {
   if (cb.checked) {
     actualPubDateRow.style.display = "none";
     // Transfer content of actual pub date to ADD if there is something there
-    var addField = document.getElementById("add-field");
     var actualField = document.getElementById("actual-pub-date-field");
     if (actualField.value.length > 0) {
       addField.value = actualField.value;
@@ -243,15 +245,37 @@ function toggleADD() {
 
 // Called whenever the user checks or unchecks the pub date or crown checkbox.
 // Synchronizes other checkbox to current selection,
-// synchronizes the date label with the pub date checkbox,
-// and refreshes the rights prediction.
+// synchronizes the date label with the pub date checkbox.
 function checkboxSelectionChanged(id) {
   if (id === 'pub-checkbox') {
     syncCheckboxes(false, id, 'crown-checkbox');
+    if (document.getElementById(id).checked) {
+      saveADD();
+    } else {
+      restoreADD();
+    }
   } else {
     syncCheckboxes(true, id, 'pub-checkbox');
   }
   toggleADD();
+}
+
+// Called when the user selects the pub date checkbox.
+function saveADD() {
+  console.log("AHOY saveADD");
+  var addField = document.getElementById("add-field");
+  var actualField = document.getElementById("actual-pub-date-field");
+  if (actualField.value.length > 0) {
+    gSavedADD = addField.value;
+  }
+}
+
+// Called when the user deselects the pub date checkbox.
+function restoreADD() {
+  var addField = document.getElementById("add-field");
+  if (gSavedADD.length > 0) {
+    addField.value = gSavedADD;
+  }
 }
 
 // Propagate checkedness across category/subcategory boundary.

--- a/cgi/partial/sbcr_form.tt
+++ b/cgi/partial/sbcr_form.tt
@@ -120,7 +120,7 @@
     
     
   </table>
-[% rights = crms.Rights(htid, 1) %]
+
 <div id="RightsCont" class="subpartial">
   [% INCLUDE partial/rights.tt %]
 

--- a/cgi/partial/sbcr_form.tt
+++ b/cgi/partial/sbcr_form.tt
@@ -8,6 +8,7 @@
 [% u_pub = (error)? cgi.param('pub') : data.reviews.$user.data.pub %]
 [% u_crown = (error)? cgi.param('crown') : data.reviews.$user.data.crown %]
 [% u_actual = (error)? cgi.param('actual') : data.reviews.$user.data.actual %]
+[% u_approximate = (error)? cgi.param('approximate') : data.reviews.$user.data.approximate %]
 [% u_rights = (error)? cgi.param('rights') : data.reviews.$user.rights %]
 [% u_category = (error)? cgi.param('category') : data.reviews.$user.category %]
 [% u_note = (error)? cgi.param('note') : data.reviews.$user.note %]
@@ -112,57 +113,18 @@
     </tr>
     <tr>
       <td colspan="2" class="reviewGrey">
-        <span id="rights-description"></span>
+        <input type="checkbox" id="approximate-checkbox" name="approximate"[% (u_approximate)? ' checked="checked"':'' %]
+               onchange="checkboxSelectionChanged(this.id);"/>
+        <label for="approximate-checkbox">&nbsp;Pub&nbsp;Date&nbsp;is&nbsp;Approximate</label>
       </td>
     </tr>
+    
     
   </table>
 [% rights = crms.Rights(htid, 1) %]
 <div id="RightsCont" class="subpartial">
-<div id="RightsReason" style="position:relative;">
-  <div id="rightsHelp" style="position:absolute;top:0px;right:1em;">
-    <a class="tip" href="#">
-      <img width="16" height="16" alt="Rights/Reason Help" src="[% crms.WebPath('web', 'help.png') %]"/>
-      <span>
-      [% asterisk = 0 %]
-      [% FOR right IN rights %]
-        <strong>[% right.rights %]</strong> - [% right.description %]<br/>
-        [% IF right.description.search('\*') %][% asterisk = 1 %][% END %]
-      [% END %]
-      [% IF asterisk %]
-        <br/>* if no publication date listed on piece, use copyright date
-      [% END %]
-      </span>
-    </a>
-  </div>
-  [% rights = crms.Rights(htid) %]
-  [% of = rights.size() %]
-  [% n = 0 %]
-    <table>
-    [% WHILE n < of %]
-      <tr>
-      [% right = rights.$n %]
-      <td style="width:50%;">
-        <input type="radio" id="[% 'r' _ right.id %]" name="rights" value="[% right.id %]"
-              [% IF right.n < 10 %]accesskey="[% right.n %]"[% END %]
-              [% IF u_rights == right.id %] checked="checked"[% END %]/>
-        <label for="[% 'r' _ right.id %]">[% right.attr %]/[% right.reason.upper %] ([% right.n %])</label>
-      </td>
-      [% n = n + 1 %]
-      <td style="width:50%;">
-        [% IF n < of %]
-        [% right = rights.$n %]
-        <input type="radio" id="[% 'r' _ right.id %]" name="rights" value="[% right.id %]"
-              [% IF right.n < 10 %]accesskey="[% right.n %]"[% END %]
-              [% IF u_rights == right.id %] checked="checked"[% END %]/>
-        <label for="[% 'r' _ right.id %]">[% right.attr %]/[% right.reason.upper %] ([% right.n %])</label>
-        [% END %]
-      </td>
-      </tr>
-      [% n = n + 1 %]
-    [% END %]
-    </table>
-</div>
+  [% INCLUDE partial/rights.tt %]
+
 <div id="Notes">
   <strong><label for="catMenu">Notes: </label></strong>
   <select id="catMenu" class="review" name="category">
@@ -291,16 +253,26 @@ function partial_sbcr_form_mainWindowLoad(e) {
 // or provisional match.
 function insertUserReviewData(user) {
   var review = gReviewData.reviews[user];
-  var button = document.getElementById("r" + review.rights);
-  if (button) { button.checked = "checked"; }
+  // Renewal
+  var field = document.getElementById("renNum");
+  if (field) { field.value = review.data?.renNum || ''; }
+  field = document.getElementById("renDate");
+  if (field) { field.value = review.data?.renDate || ''; }
+  // ADD/Pub
+  field = document.getElementById("add-field");
+  if (field) { field.value = review.data?.date || ''; }
+  var field = document.getElementById("actual-pub-date-field");
+  if (field) { field.value = review.data?.actual || ""; }
   button = document.getElementById("pub-checkbox");
   if (button) { button.checked = Boolean(review.data?.pub); }
   button = document.getElementById("crown-checkbox");
   if (button) { button.checked = Boolean(review.data?.crown); }
-  var field = document.getElementById("add-field");
-  if (field) { field.value = review.data?.date || ''; }
-  var field = document.getElementById("actual-pub-date-field");
-  if (field) { field.value = review.data?.actual || ""; }
+  button = document.getElementById("approximate-checkbox");
+  if (button) { button.checked = Boolean(review.data?.approximate); }
+  // Rights
+  var button = document.getElementById("r" + review.rights);
+  if (button) { button.checked = "checked"; }
+  // Note
   document.submitReview.note.value = review.note || "";
   selMenuItem("category-menu", review.category || "");
   toggleADD();

--- a/docker/db/sql/001_crms_schema.sql
+++ b/docker/db/sql/001_crms_schema.sql
@@ -1037,7 +1037,8 @@ CREATE TABLE `rights` (
   `attr` tinyint(4) NOT NULL,
   `reason` tinyint(4) NOT NULL,
   `description` text,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `unique_attr_reason` (`attr`,`reason`)
 ) ENGINE=InnoDB AUTO_INCREMENT=26 DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/lib/CRMS/Entitlements.pm
+++ b/lib/CRMS/Entitlements.pm
@@ -8,6 +8,10 @@ package CRMS::Entitlements;
 # Manages an in-memory copy of the crms.rights table
 # and through it the attributes and reasons it ties together.
 
+# As of CRMS version 8.7.1 the crms.rights table has a UNIQUE constraint on the attr,reason
+# combination. As a result, a method like `rights_by_attribute_reason` need never worry
+# about handling more than one result.
+
 use strict;
 use warnings;
 
@@ -24,9 +28,9 @@ sub new {
   my $crms = $args{crms};
   die "CRMS::Entitlements module needs CRMS instance." unless defined $crms;
   $self->{crms} = $crms;
-  # Eager load lookup tables
-  $self->_load_tables;
   if (!defined $ONE_TRUE_ENTITLEMENTS) {
+    # Eager load lookup tables
+    $self->_load_tables;
     $ONE_TRUE_ENTITLEMENTS = $self;
   }
   return $ONE_TRUE_ENTITLEMENTS;

--- a/lib/CRMS/Entitlements.pm
+++ b/lib/CRMS/Entitlements.pm
@@ -1,0 +1,126 @@
+package CRMS::Entitlements;
+
+# NOTE THIS IS A TEMPORARY NAME
+# CRMS::Rights conflicts with a method defined in the CRMS module
+# Once this module is proven, it can replace some/all of the rights/attributes/reasons
+# methods in CRMS.pm
+
+# Manages an in-memory copy of the crms.rights table
+# and through it the attributes and reasons it ties together.
+
+use strict;
+use warnings;
+
+use Data::Dumper;
+
+# This is a singleton. Rights, attributes, and reasons are static and can be cached.
+# Derivatives based on project_rights, if any, should not be cached because they can change.
+my $ONE_TRUE_ENTITLEMENTS;
+
+sub new {
+  my ($class, %args) = @_;
+  my $self = bless {}, $class;
+  # TODO: once we have a standalone DB module this can go away.
+  my $crms = $args{crms};
+  die "CRMS::Entitlements module needs CRMS instance." unless defined $crms;
+  $self->{crms} = $crms;
+  # Eager load lookup tables
+  $self->_load_tables;
+  if (!defined $ONE_TRUE_ENTITLEMENTS) {
+    $ONE_TRUE_ENTITLEMENTS = $self;
+  }
+  return $ONE_TRUE_ENTITLEMENTS;
+}
+
+sub rights_by_id {
+  my $self = shift;
+  my $id   = shift;
+
+  return $self->{rights}->{$id};
+}
+
+sub rights_by_attribute_reason {
+  my $self      = shift;
+  my $attribute = shift;
+  my $reason    = shift;
+
+  # Translate attribute and reason into ids if not numeric
+  if ($attribute !~ m/^\d+$/) {
+    $attribute = $self->attribute_by_name($attribute)->{id};
+  }
+  if ($reason !~ m/^\d+$/) {
+    $reason = $self->reason_by_name($reason)->{id};
+  }
+  foreach my $id (keys %{$self->{rights}}) {
+    my $rights = $self->{rights}->{$id};
+    if ($rights->{attr} == $attribute && $rights->{reason} == $reason) {
+      return $rights;
+    }
+  }
+}
+
+# Returns a hashref with the fields id, type, dscr, name just as they appear in the
+# `attributes` table
+sub attribute_by_id {
+  my $self = shift;
+  my $id   = shift;
+
+  return $self->{attributes_by_id}->{$id};
+}
+
+# Returns a hashref with the fields id, type, dscr, name just as they appear in the
+# `attributes` table
+sub attribute_by_name {
+  my $self = shift;
+  my $name = shift;
+
+  return $self->{attributes_by_name}->{$name};
+}
+
+# Returns a hashref with the fields id, dscr, name just as they appear in the
+# `reasons` table
+sub reason_by_id {
+  my $self = shift;
+  my $id   = shift;
+
+  return $self->{reasons_by_id}->{$id};
+}
+
+# Returns a hashref with the fields id, dscr, name just as they appear in the
+# `reasons` table
+sub reason_by_name {
+  my $self = shift;
+  my $name = shift;
+
+  return $self->{reasons_by_name}->{$name};
+}
+
+# Set up slightly duplicative lookup tables for fast attribute/reason access by id or by name.
+# Also set up rights lookup by id.
+sub _load_tables {
+  my $self = shift;
+
+  # crms.attributes
+  my $sql = 'SELECT * FROM attributes ORDER BY id';
+  $self->{attributes_by_id} = $self->{crms}->GetDb->selectall_hashref($sql, 'id');
+  $self->{attributes_by_name} = $self->{crms}->GetDb->selectall_hashref($sql, 'name');
+  # crms.reasons
+  $sql = 'SELECT * FROM reasons ORDER BY id';
+  $self->{reasons_by_id} = $self->{crms}->GetDb->selectall_hashref($sql, 'id');
+  $self->{reasons_by_name} = $self->{crms}->GetDb->selectall_hashref($sql, 'name');
+  # crms.rights
+  $self->{rights} = {};
+  $sql = 'SELECT * FROM rights ORDER BY id';
+  $self->{rights} = $self->{crms}->GetDb->selectall_hashref($sql, 'id');
+  # Decorare each entry with attribute and reason names
+  foreach my $id (keys %{$self->{rights}}) {
+    my $rights = $self->{rights}->{$id};
+    my $attr_name = $self->attribute_by_id($rights->{attr})->{name};
+    my $reason_name = $self->reason_by_id($rights->{reason})->{name};
+    $rights->{attribute_name} = $attr_name;
+    $rights->{reason_name} = $reason_name;
+    $rights->{name} = "$attr_name/$reason_name";
+  }
+}
+
+1;

--- a/lib/CRMS/Version.pm
+++ b/lib/CRMS/Version.pm
@@ -3,6 +3,6 @@ package CRMS::Version;
 use strict;
 use warnings;
 
-our $VERSION = '8.7.1';
+our $VERSION = '8.8.0';
 
 1;

--- a/t/CRMS.t
+++ b/t/CRMS.t
@@ -173,4 +173,16 @@ subtest '#Field008Formatter' => sub {
   isa_ok $crms->Field008Formatter, "CRMS::Field008Formatter";
 };
 
+subtest '#Field008Formatter' => sub {
+  isa_ok $crms->Field008Formatter, "CRMS::Field008Formatter";
+};
+
+subtest 'array_to_pairs' => sub {
+  is_deeply($crms->array_to_pairs([]), [], 'no elements');
+  is_deeply($crms->array_to_pairs([1]), [[1, undef]], 'one element');
+  is_deeply($crms->array_to_pairs([1, 2]), [[1, 2]], 'two elements');
+  is_deeply($crms->array_to_pairs([1, 2, 3]), [[1, 2], [3, undef]], 'three elements');
+  is_deeply($crms->array_to_pairs([1, 2, 3, 4]), [[1, 2], [3, 4]], 'four elements');
+};
+
 done_testing();

--- a/t/Project.t
+++ b/t/Project.t
@@ -2,11 +2,14 @@
 
 use strict;
 use warnings;
-BEGIN { unshift(@INC, $ENV{'SDRROOT'}. '/crms/cgi'); }
 
 use Test::More;
 
+use lib $ENV{'SDRROOT'} . '/crms/cgi';
+use lib $ENV{'SDRROOT'} . '/crms/lib';
+
 use CRMS;
+use CRMS::Entitlements;
 
 my $dir = $ENV{'SDRROOT'}. '/crms/cgi/Project';
 opendir(DIR, $dir) or die "Can't open $dir\n";
@@ -20,6 +23,12 @@ foreach my $file (sort @files)
 }
 
 my $crms = CRMS->new;
+my $entitlements = CRMS::Entitlements->new(crms => $crms);
+# Rights ids used across subtests
+
+my $ic_cdpp_rights_id = $entitlements->rights_by_attribute_reason('ic', 'cdpp')->{id};
+my $und_nfi_rights_id = $entitlements->rights_by_attribute_reason('und', 'nfi')->{id};
+my $und_ren_rights_id = $entitlements->rights_by_attribute_reason('und', 'ren')->{id};
 
 my $project = Project->new(crms => $crms);
 subtest '#queue_order' => sub {
@@ -28,6 +37,328 @@ subtest '#queue_order' => sub {
 
 subtest '#PresentationOrder' => sub {
   is($project->PresentationOrder, undef, 'default project has no PresentationOrder');
+};
+
+subtest 'ValidateSubmission' => sub {
+  subtest 'no rights selected' => sub {
+    my $cgi = CGI->new;
+    my $err = $project->ValidateSubmission($cgi);
+    ok($err =~ m/rights\/reason combination/, 'error displayed');
+  };
+
+  subtest 'und/nfi must include note category and note text' => sub {
+    subtest 'with category and note' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $und_nfi_rights_id);
+      $cgi->param('category', 'Edition');
+      $cgi->param('note', 'This is a note');
+      my $err = $project->ValidateSubmission($cgi);
+      ok($err !~ m/must include note category and note text/, 'no error');
+    };
+
+    subtest 'without category' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $und_nfi_rights_id);
+      # Setting the category explicitly to empty string is needed to avoid
+      # "uninitialized value $category" warnings in Project.pm.
+      # These can be all removed when that is fixed with a default empty string value.
+      $cgi->param('category', '');
+      $cgi->param('note', 'This is a note');
+      my $err = $project->ValidateSubmission($cgi);
+      ok($err =~ m/must include note category and note text/, 'error displayed');
+    };
+
+    subtest 'with neither' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $und_nfi_rights_id);
+      $cgi->param('category', '');
+      my $err = $project->ValidateSubmission($cgi);
+      ok($err =~ m/must include note category and note text/, 'error displayed');
+    };
+  };
+  
+  subtest 'ic/ren must include renewal id and renewal date' => sub {
+    my $ic_ren_rights_id = $entitlements->rights_by_attribute_reason('ic', 'ren')->{id};
+    subtest 'with renewal data' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $ic_ren_rights_id);
+      $cgi->param('renNum', 'R123');
+      $cgi->param('renDate', '4Jun23');
+      $cgi->param('category', '');
+      my $err = $project->ValidateSubmission($cgi);
+      ok($err !~ m/must include renewal id and renewal date/, 'no error');
+    };
+
+    subtest 'with just renewal id' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $ic_ren_rights_id);
+      $cgi->param('renNum', 'R123');
+      $cgi->param('category', '');
+      my $err = $project->ValidateSubmission($cgi);
+      ok($err =~ m/must include renewal id and renewal date/, 'error displayed');
+    };
+
+    subtest 'without renewal data' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $ic_ren_rights_id);
+      $cgi->param('category', '');
+      my $err = $project->ValidateSubmission($cgi);
+      ok($err =~ m/must include renewal id and renewal date/, 'error displayed');
+    };
+  };
+  
+  subtest 'pd/ren should not include renewal info' => sub {
+    my $pd_ren_rights_id = $entitlements->rights_by_attribute_reason('pd', 'ren')->{id};
+    subtest 'without renewal info' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $pd_ren_rights_id);
+      $cgi->param('category', '');
+      my $err = $project->ValidateSubmission($cgi);
+      ok($err !~ m/should not include renewal info/, 'no error');
+    };
+
+    # FIXME: next two tests show arguably incorrect behavior, the error should be triggered if either
+    # renNum or renDate is present. The assumption has been that renDate will always be present
+    # if renNum is, and that's maybe not quite true.
+    subtest 'with renNum' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $pd_ren_rights_id);
+      $cgi->param('renNum', 'R123');
+      $cgi->param('category', '');
+      my $err = $project->ValidateSubmission($cgi);
+      ok($err !~ m/should not include renewal info/, 'no error');
+    };
+  
+    subtest 'with renDate' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $pd_ren_rights_id);
+      $cgi->param('renDate', '4Jun23');
+      $cgi->param('category', '');
+      my $err = $project->ValidateSubmission($cgi);
+      ok($err !~ m/should not include renewal info/, 'no error');
+    };
+    
+    subtest 'with both' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $pd_ren_rights_id);
+      $cgi->param('renDate', '4Jun23');
+      $cgi->param('category', '');
+      my $err = $project->ValidateSubmission($cgi);
+      ok($err !~ m/should not include renewal info/, 'error displayed');
+    };
+  };
+
+  subtest 'pd*/cdpp must not include renewal data' => sub {
+    foreach my $attr ('pd', 'pdus') {
+      my $rights = $entitlements->rights_by_attribute_reason($attr, 'cdpp')->{id};
+      subtest "$attr with renewal number" => sub {
+        my $cgi = CGI->new;
+        $cgi->param('rights', $rights);
+        $cgi->param('renNum', 'R123');
+        $cgi->param('category', '');
+        my $err = $project->ValidateSubmission($cgi);
+        ok($err =~ m/must not include renewal info/, 'error displayed');
+      };
+
+      subtest "$attr with renewal date" => sub {
+        my $cgi = CGI->new;
+        $cgi->param('rights', $rights);
+        $cgi->param('renDate', '4Jun23');
+        $cgi->param('category', '');
+        my $err = $project->ValidateSubmission($cgi);
+        ok($err =~ m/must not include renewal info/, 'error displayed');
+      };
+
+      subtest "$attr without renewal data" => sub {
+        my $cgi = CGI->new;
+        $cgi->param('rights', $rights);
+        $cgi->param('category', '');
+        my $err = $project->ValidateSubmission($cgi);
+        ok($err !~ m/must not include renewal info/, 'no error');
+      };
+    }
+  };
+
+  subtest 'pd/cdpp must include note category and note text' => sub {
+    my $rights = $entitlements->rights_by_attribute_reason('pd', 'cdpp')->{id};
+    subtest 'with both' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $rights);
+      $cgi->param('category', 'Edition');
+      $cgi->param('note', 'This is a note');
+      my $err = $project->ValidateSubmission($cgi);
+      ok($err !~ m/must include note category and note text/, 'no error');
+    };
+
+    subtest 'with note only' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $rights);
+      $cgi->param('category', '');
+      $cgi->param('note', 'This is a note');
+      my $err = $project->ValidateSubmission($cgi);
+      ok($err =~ m/must include note category and note text/, 'error displayed');
+    };
+
+    subtest 'with neither' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $rights);
+      $cgi->param('category', '');
+      my $err = $project->ValidateSubmission($cgi);
+      ok($err =~ m/must include note category and note text/, 'error displayed');
+    };
+  };
+
+  # NOTE: this could be merged with the pd/cdpp and pdus/cdpp logic above
+  subtest 'ic/cdpp must not include renewal data' => sub {
+    subtest 'with renewal number' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $ic_cdpp_rights_id);
+      $cgi->param('renNum', 'R123');
+      $cgi->param('category', '');
+      my $err = $project->ValidateSubmission($cgi);
+      ok($err =~ m/should not include renewal info/, 'error displayed');
+    };
+    
+    subtest 'with renewal date' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $ic_cdpp_rights_id);
+      $cgi->param('renDate', '4Jun23');
+      $cgi->param('category', '');
+      my $err = $project->ValidateSubmission($cgi);
+      ok($err =~ m/should not include renewal info/, 'error displayed');
+    };
+  };
+
+  # NOTE: this could be merged with the pd/cdpp and pdus/cdpp logic above
+  subtest 'ic/cdpp must include note category and note text' => sub {
+    subtest 'with both' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $ic_cdpp_rights_id);
+      $cgi->param('category', 'Edition');
+      $cgi->param('note', 'This is a note');
+      my $err = $project->ValidateSubmission($cgi);
+      ok($err !~ m/must include note category and note text/, 'no error');
+    };
+
+    subtest 'with note only' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $ic_cdpp_rights_id);
+      $cgi->param('category', '');
+      $cgi->param('note', 'This is a note');
+      my $err = $project->ValidateSubmission($cgi);
+      ok($err =~ m/must include note category and note text/, 'error displayed');
+    };
+
+    subtest 'with neither' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $ic_cdpp_rights_id);
+      $cgi->param('category', '');
+      my $err = $project->ValidateSubmission($cgi);
+      ok($err =~ m/must include note category and note text/, 'error displayed');
+    };
+  };
+
+  subtest 'und/ren must have note category Inserts/No Renewal' => sub {
+    subtest 'with expected category' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $und_ren_rights_id);
+      $cgi->param('category', 'Inserts/No Renewal');
+      my $err = $project->ValidateSubmission($cgi);
+      ok($err !~ m/mmust have note category Inserts\/No Renewal/, 'no error');
+    };
+
+    subtest 'without expected category' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $und_ren_rights_id);
+      $cgi->param('category', 'Edition');
+      my $err = $project->ValidateSubmission($cgi);
+      ok($err =~ m/must have note category Inserts\/No Renewal/, 'no error');
+    };
+
+    subtest 'with no category' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $und_ren_rights_id);
+      $cgi->param('category', '');
+      my $err = $project->ValidateSubmission($cgi);
+      ok($err =~ m/must have note category/, 'error displayed');
+    };
+  };
+
+  subtest 'Inserts/No Renewal category is only used with und/ren' => sub {
+    subtest 'with expected rights' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $und_ren_rights_id);
+      $cgi->param('category', 'Inserts/No Renewal');
+      my $err = $project->ValidateSubmission($cgi);
+      ok($err !~ m/must have rights code/, 'no error');
+    };
+
+    subtest 'without expected rights' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $und_nfi_rights_id);
+      $cgi->param('category', 'Inserts/No Renewal');
+      my $err = $project->ValidateSubmission($cgi);
+      ok($err =~ m/must have rights code/, 'error displayed');
+    };
+  };
+
+  subtest "note optionality" => sub {
+    my $note_required = $crms->SimpleSqlGet('SELECT name FROM categories WHERE need_note=1 AND interface=1 AND restricted IS NULL');
+    my $note_optional = $crms->SimpleSqlGet('SELECT name FROM categories WHERE need_note=0 AND interface=1 AND restricted IS NULL');
+    subtest 'category without required note' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', 1);
+      $cgi->param('category', $note_required);
+      my $err = $project->ValidateSubmission($cgi);
+      ok($err =~ m/must include a note/, 'error displayed');
+    };
+
+    subtest 'category with required note' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', 1);
+      $cgi->param('category', $note_required);
+      $cgi->param('note', 'This is a required note');
+      my $err = $project->ValidateSubmission($cgi);
+      ok($err !~ m/must include a note/, 'no error');
+    };
+
+    subtest 'category without optional note' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', 1);
+      $cgi->param('category', $note_optional);
+      my $err = $project->ValidateSubmission($cgi);
+      ok($err !~ m/must include a note/, 'no error');
+    };
+
+    subtest 'category with required note' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', 1);
+      $cgi->param('category', $note_optional);
+      $cgi->param('note', 'This is an optional note');
+      my $err = $project->ValidateSubmission($cgi);
+      ok($err !~ m/must include a note/, 'no error');
+    };
+  };
+
+  subtest 'must include a category if there is a note' => sub {
+    subtest 'note with category' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', 1);
+      $cgi->param('note', 'This is a note');
+      $cgi->param('category', 'Misc');
+      my $err = $project->ValidateSubmission($cgi);
+      ok($err !~ m/must include a category/, 'no error');
+    };
+
+    subtest 'note without category' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', 1);
+      $cgi->param('category', '');
+      $cgi->param('note', 'This is a note');
+      my $err = $project->ValidateSubmission($cgi);
+      ok($err =~ m/must include a category/, 'error displayed');
+    };
+  };
 };
 
 done_testing();

--- a/t/Project/CrownCopyright.t
+++ b/t/Project/CrownCopyright.t
@@ -1,0 +1,58 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use utf8;
+
+use CGI;
+use Test::More;
+
+use lib $ENV{'SDRROOT'} . '/crms/cgi';
+use lib $ENV{'SDRROOT'} . '/crms/lib';
+use CRMS;
+use CRMS::Entitlements;
+
+my $crms = CRMS->new();
+my $entitlements = CRMS::Entitlements->new(crms => $crms);
+
+require_ok($ENV{'SDRROOT'}. '/crms/cgi/Project/CrownCopyright.pm');
+
+my $sql = 'SELECT id FROM projects WHERE name="Crown Copyright"';
+my $project_id = $crms->SimpleSqlGet($sql);
+my $project = CrownCopyright->new(crms => $crms, id => $project_id);
+ok(defined $project);
+
+subtest 'ValidateSubmission' => sub {
+  subtest 'no rights selected' => sub {
+    my $cgi = CGI->new;
+    my $err = $project->ValidateSubmission($cgi);
+    ok($err =~ m/rights\/reason combination/);
+  };
+
+  subtest 'Not Government category requires und/NFI' => sub {
+    subtest 'Not Government category with und/nfi' => sub {
+      my $rights = $entitlements->rights_by_attribute_reason('und', 'nfi')->{id};
+      my $cgi = CGI->new;
+      $cgi->param('rights', $rights);
+      # Setting the date explicitly to empty string is needed to avoid
+      # "uninitialized value $date" warnings in CrownCopyright.pm.
+      # These can be all removed when that is fixed with a default empty string value.
+      $cgi->param('date', '');
+      $cgi->param('category', 'Not Government');
+      my $err = $project->ValidateSubmission($cgi);
+      ok($err !~ m/Not Government category requires/);
+    };
+
+    subtest 'Not Government category without und/nfi' => sub {
+      my $rights = $entitlements->rights_by_attribute_reason('ic', 'ren')->{id};
+      my $cgi = CGI->new;
+      $cgi->param('rights', $rights);
+      $cgi->param('date', '');
+      $cgi->param('category', 'Not Government');
+      my $err = $project->ValidateSubmission($cgi);
+      ok($err =~ m/Not Government category requires/);
+    };
+  };
+};
+
+done_testing();

--- a/t/Project/SBCR.t
+++ b/t/Project/SBCR.t
@@ -18,33 +18,27 @@ my $jsonxs = JSON::XS->new->utf8->canonical(1)->pretty(0);
 # Will be used multiple times in this test suite.
 my $crms = CRMS->new();
 my $entitlements = CRMS::Entitlements->new(crms => $crms);
-# Grab the most frequently used rights ids
-my $ic_ren_rights_id = $entitlements->rights_by_attribute_reason('ic', 'ren')->{id};
-my $pd_ren_rights_id = $entitlements->rights_by_attribute_reason('pd', 'ren')->{id};
-my $ic_cdpp_rights_id = $entitlements->rights_by_attribute_reason('ic', 'cdpp')->{id};
-my $und_nfi_rights_id = $entitlements->rights_by_attribute_reason('und', 'nfi')->{id};
-my $und_ren_rights_id = $entitlements->rights_by_attribute_reason('und', 'ren')->{id};
 
 require_ok($ENV{'SDRROOT'}. '/crms/cgi/Project/SBCR.pm');
 
 my $sql = 'SELECT id FROM projects WHERE name="SBCR"';
 my $project_id = $crms->SimpleSqlGet($sql);
-my $proj = SBCR->new(crms => $crms, id => $project_id);
-ok(defined $proj);
+my $project = SBCR->new(crms => $crms, id => $project_id);
+ok(defined $project);
 
-subtest 'SBCR::PresentationOrder' => sub {
-  my $order = $proj->PresentationOrder;
+subtest 'PresentationOrder' => sub {
+  my $order = $project->PresentationOrder;
   ok(!defined $order, 'does not define a presentation order');
 };
 
-subtest 'SBCR::ReviewPartials' => sub {
-  ok(defined $proj->ReviewPartials, 'defines a UI ordering');
+subtest 'ReviewPartials' => sub {
+  ok(defined $project->ReviewPartials, 'defines a UI ordering');
 };
 
-subtest 'SBCR::ValidateSubmission' => sub {
+subtest 'ValidateSubmission' => sub {
   subtest 'no rights selected' => sub {
     my $cgi = CGI->new;
-    my $err = $proj->ValidateSubmission($cgi);
+    my $err = $project->ValidateSubmission($cgi);
     ok($err =~ m/rights\/reason combination/);
   };
 
@@ -54,7 +48,7 @@ subtest 'SBCR::ValidateSubmission' => sub {
         my $cgi = CGI->new;
         $cgi->param('rights', 1);
         $cgi->param('date', $date);
-        my $err = $proj->ValidateSubmission($cgi);
+        my $err = $project->ValidateSubmission($cgi);
         ok($err !~ m/date must be only decimal digits/);
       }
     };
@@ -64,7 +58,7 @@ subtest 'SBCR::ValidateSubmission' => sub {
         my $cgi = CGI->new;
         $cgi->param('rights', 1);
         $cgi->param('date', $date);
-        my $err = $proj->ValidateSubmission($cgi);
+        my $err = $project->ValidateSubmission($cgi);
         ok($err =~ m/date must be only decimal digits/);
       }
     };
@@ -72,7 +66,7 @@ subtest 'SBCR::ValidateSubmission' => sub {
     subtest 'no date submitted' => sub {
       my $cgi = CGI->new;
       $cgi->param('rights', 1);
-      my $err = $proj->ValidateSubmission($cgi);
+      my $err = $project->ValidateSubmission($cgi);
       ok($err !~ m/date must be only decimal digits/);
     };
   };
@@ -85,15 +79,14 @@ subtest 'SBCR::ValidateSubmission' => sub {
           my $cgi = CGI->new;
           $cgi->param('rights', $rights->{id});
           $cgi->param('date', 1957);
-          my $err = $proj->ValidateSubmission($cgi);
+          my $err = $project->ValidateSubmission($cgi);
           ok($err !~ m/must include a numeric year/);
         };
 
         subtest "$rights->{name} without date" => sub {
           my $cgi = CGI->new;
           $cgi->param('rights', $rights->{id});
-          #$cgi->param('date', 1957);
-          my $err = $proj->ValidateSubmission($cgi);
+          my $err = $project->ValidateSubmission($cgi);
           ok($err =~ m/must include a numeric year/);
         };
       } else {
@@ -101,88 +94,37 @@ subtest 'SBCR::ValidateSubmission' => sub {
           my $cgi = CGI->new;
           $cgi->param('rights', $rights->{id});
           $cgi->param('date', 1957);
-          my $err = $proj->ValidateSubmission($cgi);
+          my $err = $project->ValidateSubmission($cgi);
           ok($err !~ m/must include a numeric year/);
         };
       }
     }
   };
 
-  subtest 'renewal ... has expired: volume is pd' => sub {
-    subtest 'ic/ren with nonexpired renewal' => sub {
-      my $cgi = CGI->new;
-      $cgi->param('rights', $ic_ren_rights_id);
-      $cgi->param('renNum', 'R123');
-      $cgi->param('renDate', '4Jun63');
-      my $err = $proj->ValidateSubmission($cgi);
-      ok($err !~ m/renewal .*? has expired: volume is pd/);
-    };
-
-    subtest 'ic/ren with expired renewal date' => sub {
-      my $cgi = CGI->new;
-      $cgi->param('rights', $ic_ren_rights_id);
-      $cgi->param('renNum', 'R123');
-      $cgi->param('renDate', '4Jun23');
-      my $err = $proj->ValidateSubmission($cgi);
-      ok($err =~ m/renewal .*? has expired: volume is pd/);
-    };
-    
-    subtest 'ic/ren with unparseable renewal date' => sub {
-      my $cgi = CGI->new;
-      $cgi->param('rights', $ic_ren_rights_id);
-      $cgi->param('renNum', 'R123');
-      $cgi->param('renDate', 'unparseable');
-      my $err = $proj->ValidateSubmission($cgi);
-      ok($err !~ m/renewal .*? has expired: volume is pd/);
-    };
-
-    subtest 'ic/ren with no renewal date' => sub {
-      my $cgi = CGI->new;
-      $cgi->param('rights', $ic_ren_rights_id);
-      $cgi->param('renNum', 'R123');
-      my $err = $proj->ValidateSubmission($cgi);
-      ok($err !~ m/renewal .*? has expired: volume is pd/);
-    };
-
-    subtest 'not ic/ren' => sub {
-      my $cgi = CGI->new;
-      $cgi->param('rights', $pd_ren_rights_id);
-      $cgi->param('renNum', 'R123');
-      $cgi->param('renDate', '4Jun23');
-      my $err = $proj->ValidateSubmission($cgi);
-      ok($err !~ m/renewal .*? has expired: volume is pd/);
-    };
-  };
-
   subtest 'ic/ren must include renewal id and renewal date' => sub {
-    my $cgi = CGI->new;
-    $cgi->param('rights', $ic_ren_rights_id);
-    my $err = $proj->ValidateSubmission($cgi);
-    ok($err =~ m/must include renewal id and renewal date/);
-  };
-
-  subtest 'pd/ren should not include renewal info' => sub {
-    subtest 'without renewal info' => sub {
+    my $ic_ren_rights_id = $entitlements->rights_by_attribute_reason('ic', 'ren')->{id};
+    subtest 'with renewal data' => sub {
       my $cgi = CGI->new;
-      $cgi->param('rights', $pd_ren_rights_id);
-      my $err = $proj->ValidateSubmission($cgi);
-      ok($err !~ m/should not include renewal info/);
-    };
-
-    subtest 'with renNum' => sub {
-      my $cgi = CGI->new;
-      $cgi->param('rights', $pd_ren_rights_id);
+      $cgi->param('rights', $ic_ren_rights_id);
       $cgi->param('renNum', 'R123');
-      my $err = $proj->ValidateSubmission($cgi);
-      ok($err =~ m/should not include renewal info/);
+      $cgi->param('renDate', '4Jun23');
+      my $err = $project->ValidateSubmission($cgi);
+      ok($err !~ m/must include renewal id and renewal date/);
     };
 
-    subtest 'with renDate' => sub {
+    subtest 'with just renewal id' => sub {
       my $cgi = CGI->new;
-      $cgi->param('rights', $pd_ren_rights_id);
-      $cgi->param('renDate', '4Jun23');
-      my $err = $proj->ValidateSubmission($cgi);
-      ok($err =~ m/should not include renewal info/);
+      $cgi->param('rights', $ic_ren_rights_id);
+      $cgi->param('renNum', 'R123');
+      my $err = $project->ValidateSubmission($cgi);
+      ok($err =~ m/must include renewal id and renewal date/);
+    };
+
+    subtest 'without renewal data' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $ic_ren_rights_id);
+      my $err = $project->ValidateSubmission($cgi);
+      ok($err =~ m/must include renewal id and renewal date/);
     };
   };
 
@@ -191,7 +133,7 @@ subtest 'SBCR::ValidateSubmission' => sub {
       my $cgi = CGI->new;
       $cgi->param('rights', 1);
       $cgi->param('actual', '9999');
-      my $err = $proj->ValidateSubmission($cgi);
+      my $err = $project->ValidateSubmission($cgi);
       ok($err !~ m/YYYY or YYYY-YYYY/);
     };
 
@@ -199,7 +141,7 @@ subtest 'SBCR::ValidateSubmission' => sub {
       my $cgi = CGI->new;
       $cgi->param('rights', 1);
       $cgi->param('actual', '9990-9999');
-      my $err = $proj->ValidateSubmission($cgi);
+      my $err = $project->ValidateSubmission($cgi);
       ok($err !~ m/YYYY or YYYY-YYYY/);
     };
 
@@ -207,245 +149,8 @@ subtest 'SBCR::ValidateSubmission' => sub {
       my $cgi = CGI->new;
       $cgi->param('rights', 1);
       $cgi->param('actual', 'abcde');
-      my $err = $proj->ValidateSubmission($cgi);
+      my $err = $project->ValidateSubmission($cgi);
       ok($err =~ m/YYYY or YYYY-YYYY/);
-    };
-  };
-
-  subtest 'pd*/cdpp must not include renewal data' => sub {
-    foreach my $attr ('pd', 'pdus') {
-      my $rights = $entitlements->rights_by_attribute_reason($attr, 'cdpp')->{id};
-      subtest "$attr with renewal number" => sub {
-        my $cgi = CGI->new;
-        $cgi->param('rights', $rights);
-        $cgi->param('renNum', 'R123');
-        my $err = $proj->ValidateSubmission($cgi);
-        ok($err =~ m/must not include renewal info/);
-      };
-
-      subtest "$attr with renewal date" => sub {
-        my $cgi = CGI->new;
-        $cgi->param('rights', $rights);
-        $cgi->param('renDate', '4Jun23');
-        my $err = $proj->ValidateSubmission($cgi);
-        ok($err =~ m/must not include renewal info/);
-      };
-
-      subtest "$attr without renewal data" => sub {
-        my $cgi = CGI->new;
-        $cgi->param('rights', $rights);
-        my $err = $proj->ValidateSubmission($cgi);
-        ok($err !~ m/must not include renewal info/);
-      };
-    }
-  };
-
-  subtest 'pd/cdpp must include note category and note text' => sub {
-    my $rights = $entitlements->rights_by_attribute_reason('pd', 'cdpp')->{id};
-    subtest 'with both' => sub {
-      my $cgi = CGI->new;
-      $cgi->param('rights', $rights);
-      $cgi->param('category', 'Edition');
-      $cgi->param('note', 'This is a note');
-      my $err = $proj->ValidateSubmission($cgi);
-      ok($err !~ m/must include note category and note text/);
-    };
-
-    subtest 'with note only' => sub {
-      my $cgi = CGI->new;
-      $cgi->param('rights', $rights);
-      $cgi->param('note', 'This is a note');
-      my $err = $proj->ValidateSubmission($cgi);
-      ok($err =~ m/must include note category and note text/);
-    };
-
-    subtest 'with neither' => sub {
-      my $cgi = CGI->new;
-      $cgi->param('rights', $rights);
-      my $err = $proj->ValidateSubmission($cgi);
-      ok($err =~ m/must include note category and note text/);
-    };
-  };
-
-  # NOTE: this could be merged with the pd/cdpp and pdus/cdpp logic above
-  subtest 'ic/cdpp must not include renewal data' => sub {
-    subtest 'with renewal number' => sub {
-      my $cgi = CGI->new;
-      $cgi->param('rights', $ic_cdpp_rights_id);
-      $cgi->param('renNum', 'R123');
-      my $err = $proj->ValidateSubmission($cgi);
-      ok($err =~ m/must not include renewal info/);
-    };
-    
-    subtest 'with renewal date' => sub {
-      my $cgi = CGI->new;
-      $cgi->param('rights', $ic_cdpp_rights_id);
-      $cgi->param('renDate', '4Jun23');
-      my $err = $proj->ValidateSubmission($cgi);
-      ok($err =~ m/must not include renewal info/);
-    };
-  };
-
-  # NOTE: this could be merged with the pd/cdpp and pdus/cdpp logic above
-  subtest 'ic/cdpp must include note category and note text' => sub {
-    subtest 'with both' => sub {
-      my $cgi = CGI->new;
-      $cgi->param('rights', $ic_cdpp_rights_id);
-      $cgi->param('category', 'Edition');
-      $cgi->param('note', 'This is a note');
-      my $err = $proj->ValidateSubmission($cgi);
-      ok($err !~ m/must include note category and note text/);
-    };
-
-    subtest 'with note only' => sub {
-      my $cgi = CGI->new;
-      $cgi->param('rights', $ic_cdpp_rights_id);
-      $cgi->param('note', 'This is a note');
-      my $err = $proj->ValidateSubmission($cgi);
-      ok($err =~ m/must include note category and note text/);
-    };
-
-    subtest 'with neither' => sub {
-      my $cgi = CGI->new;
-      $cgi->param('rights', $ic_cdpp_rights_id);
-      my $err = $proj->ValidateSubmission($cgi);
-      ok($err =~ m/must include note category and note text/);
-    };
-  };
-
-  subtest 'und/nfi must include note category' => sub {
-    subtest 'with category' => sub {
-      my $cgi = CGI->new;
-      $cgi->param('rights', $und_nfi_rights_id);
-      $cgi->param('category', 'Edition');
-      my $err = $proj->ValidateSubmission($cgi);
-      ok($err !~ m/must include note category/);
-    };
-
-    subtest 'without category' => sub {
-      my $cgi = CGI->new;
-      $cgi->param('rights', $und_nfi_rights_id);
-      my $err = $proj->ValidateSubmission($cgi);
-      ok($err =~ m/must include note category/);
-    };
-  };
-
-  subtest 'und/ren must have note category Inserts/No Renewal' => sub {
-    subtest 'with expected category' => sub {
-      my $cgi = CGI->new;
-      $cgi->param('rights', $und_ren_rights_id);
-      $cgi->param('category', 'Inserts/No Renewal');
-      my $err = $proj->ValidateSubmission($cgi);
-      ok($err !~ m/mmust have note category Inserts\/No Renewal/);
-    };
-
-    subtest 'without expected category' => sub {
-      my $cgi = CGI->new;
-      $cgi->param('rights', $und_ren_rights_id);
-      $cgi->param('category', 'Edition');
-      my $err = $proj->ValidateSubmission($cgi);
-      ok($err =~ m/must have note category Inserts\/No Renewal/);
-    };
-
-    subtest 'with no category' => sub {
-      my $cgi = CGI->new;
-      $cgi->param('rights', $und_ren_rights_id);
-      my $err = $proj->ValidateSubmission($cgi);
-      ok($err =~ m/must have note category /);
-    };
-  };
-  
-  subtest 'Inserts/No Renewal category is only used with und/ren' => sub {
-    subtest 'with expected rights' => sub {
-      my $cgi = CGI->new;
-      $cgi->param('rights', $und_ren_rights_id);
-      $cgi->param('category', 'Inserts/No Renewal');
-      my $err = $proj->ValidateSubmission($cgi);
-      ok($err !~ m/must have rights code/);
-    };
-
-    subtest 'without expected rights' => sub {
-      my $cgi = CGI->new;
-      $cgi->param('rights', $und_nfi_rights_id);
-      $cgi->param('category', 'Inserts/No Renewal');
-      my $err = $proj->ValidateSubmission($cgi);
-      ok($err =~ m/must have rights code/);
-    };
-  };
-
-  subtest "note optionality" => sub {
-    my $note_required = $crms->SimpleSqlGet('SELECT name FROM categories WHERE need_note=1 AND interface=1 AND restricted IS NULL');
-    my $note_optional = $crms->SimpleSqlGet('SELECT name FROM categories WHERE need_note=0 AND interface=1 AND restricted IS NULL');
-    subtest 'category without required note' => sub {
-      my $cgi = CGI->new;
-      $cgi->param('rights', 1);
-      $cgi->param('category', $note_required);
-      my $err = $proj->ValidateSubmission($cgi);
-      ok($err =~ m/requires a note/);
-    };
-
-    subtest 'category with required note' => sub {
-      my $cgi = CGI->new;
-      $cgi->param('rights', 1);
-      $cgi->param('category', $note_required);
-      $cgi->param('note', 'This is a required note');
-      my $err = $proj->ValidateSubmission($cgi);
-      ok($err !~ m/requires a note/);
-    };
-
-    subtest 'category without optional note' => sub {
-      my $cgi = CGI->new;
-      $cgi->param('rights', 1);
-      $cgi->param('category', $note_optional);
-      my $err = $proj->ValidateSubmission($cgi);
-      ok($err !~ m/requires a note/);
-    };
-
-    subtest 'category with required note' => sub {
-      my $cgi = CGI->new;
-      $cgi->param('rights', 1);
-      $cgi->param('category', $note_optional);
-      $cgi->param('note', 'This is an optional note');
-      my $err = $proj->ValidateSubmission($cgi);
-      ok($err !~ m/requires a note/);
-    };
-  };
-
-  subtest 'must include a category if there is a note' => sub {
-    subtest 'note with category' => sub {
-      my $cgi = CGI->new;
-      $cgi->param('rights', 1);
-      $cgi->param('note', 'This is a note');
-      $cgi->param('category', 'Misc');
-      my $err = $proj->ValidateSubmission($cgi);
-      ok($err !~ m/must include a category/);
-    };
-
-    subtest 'note without category' => sub {
-      my $cgi = CGI->new;
-      $cgi->param('rights', 1);
-      $cgi->param('note', 'This is a note');
-      my $err = $proj->ValidateSubmission($cgi);
-      ok($err =~ m/must include a category/);
-    };
-  };
-  
-  subtest 'Not Government category requires und/NFI' => sub {
-    subtest 'Not Government category with und/nfi' => sub {
-      my $rights = $entitlements->rights_by_attribute_reason('und', 'nfi')->{id};
-      my $cgi = CGI->new;
-      $cgi->param('rights', $rights);
-      $cgi->param('category', 'Not Government');
-      my $err = $proj->ValidateSubmission($cgi);
-      ok($err !~ m/Not Government category requires/);
-    };
-
-    subtest 'Not Government category without und/nfi' => sub {
-      my $cgi = CGI->new;
-      $cgi->param('rights', $ic_ren_rights_id);
-      $cgi->param('category', 'Not Government');
-      my $err = $proj->ValidateSubmission($cgi);
-      ok($err =~ m/Not Government category requires/);
     };
   };
   # End of ValidateSubmission subtest
@@ -461,7 +166,7 @@ subtest 'ExtractReviewData' => sub {
     $cgi->param('crown', 'on');
     $cgi->param('actual', '1960');
     $cgi->param('approximate', 'on');
-    my $extracted = $proj->ExtractReviewData($cgi);
+    my $extracted = $project->ExtractReviewData($cgi);
     is($extracted->{renNum}, 'R123');
     is($extracted->{renDate}, '26Sep39');
     is($extracted->{date}, '1950');
@@ -473,7 +178,7 @@ subtest 'ExtractReviewData' => sub {
 
   subtest 'with very little data' => sub {
     my $cgi = CGI->new;
-    my $extracted = $proj->ExtractReviewData($cgi);
+    my $extracted = $project->ExtractReviewData($cgi);
     is_deeply($extracted, {});
   };
 };
@@ -490,7 +195,7 @@ subtest 'FormatReviewData' => sub {
       approximate => 1
     };
     my $json = $jsonxs->encode($data);
-    my $format = $proj->FormatReviewData(1, $json);
+    my $format = $project->FormatReviewData(1, $json);
     ok($format->{format} =~ /Renewal/);
     ok($format->{format} =~ /ADD/);
     ok($format->{format} !~ /<strong>Pub/);
@@ -505,7 +210,7 @@ subtest 'FormatReviewData' => sub {
       pub => 1
     };
     my $json = $jsonxs->encode($data);
-    my $format = $proj->FormatReviewData(1, $json);
+    my $format = $project->FormatReviewData(1, $json);
     ok($format->{format} !~ /Renewal/);
     ok($format->{format} !~ /ADD/);
     ok($format->{format} =~ /<strong>Pub/);
@@ -517,7 +222,7 @@ subtest 'FormatReviewData' => sub {
   subtest 'with no data' => sub {
     my $data = {};
     my $json = $jsonxs->encode($data);
-    my $format = $proj->FormatReviewData(1, $json);
+    my $format = $project->FormatReviewData(1, $json);
     ok($format->{format} !~ /Renewal/);
     ok($format->{format} !~ /ADD/);
     ok($format->{format} !~ /<strong>Pub/);
@@ -531,39 +236,27 @@ subtest 'extract_parameters' => sub {
   my $cgi = CGI->new;
   $cgi->param('rights', 1);
   $cgi->param('renNum', "  R12345\n");
-  my $params = $proj->extract_parameters($cgi);
+  my $params = $project->extract_parameters($cgi);
   is($params->{rights}, 1, 'leaves rights unchanged');
   is($params->{renNum}, 'R12345', 'strips whitespace');
 };
 
 subtest 'format_renewal_data' => sub {
   subtest 'with no data' => sub {
-    ok(length $proj->format_renewal_data(undef, undef) == 0);
+    ok(length $project->format_renewal_data(undef, undef) == 0);
   };
 
   subtest 'with only renNum' => sub {
-    ok($proj->format_renewal_data('R123', undef) =~ m/R123/);
+    ok($project->format_renewal_data('R123', undef) =~ m/R123/);
   };
 
   subtest 'with only renDate' => sub {
-    ok($proj->format_renewal_data(undef, '1Oct51') =~ m/1Oct51/);
+    ok($project->format_renewal_data(undef, '1Oct51') =~ m/1Oct51/);
   };
 
   subtest 'with both renNum and renDate' => sub {
-    ok($proj->format_renewal_data('R123', '1Oct51') =~ m/R123/);
-    ok($proj->format_renewal_data('R123', '1Oct51') =~ m/1Oct51/);
-  };
-};
-
-subtest 'renewal_date_to_year' => sub {
-  subtest 'with a well-formed renewal date' => sub {
-    my $year = $proj->renewal_date_to_year('21Sep51');
-    is($year, '1951', 'extracts year');
-  };
-
-  subtest 'with a nonsense renewal date' => sub {
-    my $year = $proj->renewal_date_to_year('abcde');
-    is($year, '', 'returns empty string');
+    ok($project->format_renewal_data('R123', '1Oct51') =~ m/R123/);
+    ok($project->format_renewal_data('R123', '1Oct51') =~ m/1Oct51/);
   };
 };
 

--- a/t/Project/SBCR.t
+++ b/t/Project/SBCR.t
@@ -239,10 +239,10 @@ subtest 'SBCR::ValidateSubmission' => sub {
 };
 
 subtest 'ExtractReviewData' => sub {
-  subtest 'with lots of data' => sub {
+  subtest 'with lots of data, some of it messy' => sub {
     my $cgi = CGI->new;
-    $cgi->param('renNum', 'R123');
-    $cgi->param('renDate', '26Sep39');
+    $cgi->param('renNum', ' R123');
+    $cgi->param('renDate', ' 26Sep39');
     $cgi->param('date', '1950');
     $cgi->param('pub', 'on');
     $cgi->param('crown', 'on');

--- a/t/Project/SBCR.t
+++ b/t/Project/SBCR.t
@@ -1,0 +1,291 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use utf8;
+
+use CGI;
+use Data::Dumper;
+use Test::More;
+
+use lib $ENV{'SDRROOT'} . '/crms/cgi';
+use lib $ENV{'SDRROOT'} . '/crms/lib';
+use CRMS;
+use CRMS::Entitlements;
+
+
+require_ok($ENV{'SDRROOT'}. '/crms/cgi/Project/SBCR.pm');
+
+my $crms = CRMS->new();
+# TODO: Project::for_name would be a much nicer way to do this.
+my $sql = 'SELECT id FROM projects WHERE name="SBCR"';
+my $project_id = $crms->SimpleSqlGet($sql);
+my $proj = SBCR->new(crms => $crms, id => $project_id);
+ok(defined $proj);
+
+subtest 'SBCR::PresentationOrder' => sub {
+  my $order = $proj->PresentationOrder;
+  ok(!defined $order, 'does not define a presentation order');
+};
+
+subtest 'SBCR::ReviewPartials' => sub {
+  ok(defined $proj->ReviewPartials, 'defines a UI ordering');
+};
+
+subtest 'SBCR::ValidateSubmission' => sub {
+  subtest 'no rights selected' => sub {
+    my $cgi = CGI->new;
+    my $err = $proj->ValidateSubmission($cgi);
+    ok($err =~ m/rights\/reason combination/);
+  };
+
+  subtest 'ADD/pub date with too many digits' => sub {
+    my $cgi = CGI->new;
+    $cgi->param('rights', 1);
+    $cgi->param('date', '12345');
+    my $err = $proj->ValidateSubmission($cgi);
+    ok($err =~ m/decimal digits/);
+  };
+
+  subtest 'pd/add with no date' => sub {
+    my $cgi = CGI->new;
+    my $rights = CRMS::Entitlements->new(crms => $crms)->rights_by_attribute_reason('pd', 'add')->{id};
+    $cgi->param('rights', $rights);
+    my $err = $proj->ValidateSubmission($cgi);
+    ok($err =~ m/numeric year/);
+  };
+
+  subtest 'pd/exp with no date' => sub {
+    my $cgi = CGI->new;
+    my $rights = CRMS::Entitlements->new(crms => $crms)->rights_by_attribute_reason('pd', 'exp')->{id};
+    $cgi->param('rights', $rights);
+    my $err = $proj->ValidateSubmission($cgi);
+    ok($err =~ m/numeric year/);
+  };
+
+  subtest 'ic/ren with expired renewal' => sub {
+    my $cgi = CGI->new;
+    my $rights = CRMS::Entitlements->new(crms => $crms)->rights_by_attribute_reason('ic', 'ren')->{id};
+    $cgi->param('rights', $rights);
+    $cgi->param('renNum', 'R123');
+    $cgi->param('renDate', '4Jun23');
+    my $err = $proj->ValidateSubmission($cgi);
+    ok($err =~ m/expired/);
+  };
+
+  subtest 'ic/ren with no renewal data' => sub {
+    my $cgi = CGI->new;
+    my $rights = CRMS::Entitlements->new(crms => $crms)->rights_by_attribute_reason('ic', 'ren')->{id};
+    $cgi->param('rights', $rights);
+    my $err = $proj->ValidateSubmission($cgi);
+    ok($err =~ m/renewal id/);
+  };
+
+  subtest 'pd/ren with renewal data' => sub {
+    my $cgi = CGI->new;
+    my $rights = CRMS::Entitlements->new(crms => $crms)->rights_by_attribute_reason('pd', 'ren')->{id};
+    $cgi->param('rights', $rights);
+    $cgi->param('renNum', 'R123');
+    $cgi->param('renDate', '4Jun23');
+    my $err = $proj->ValidateSubmission($cgi);
+    ok($err =~ m/should not include renewal info/);
+  };
+
+  subtest 'actual publication date' => sub {
+    subtest 'single date' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', 1);
+      $cgi->param('actual', '9999');
+      my $err = $proj->ValidateSubmission($cgi);
+      ok($err !~ m/YYYY or YYYY-YYYY/);
+    };
+
+    subtest 'date range' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', 1);
+      $cgi->param('actual', '9990-9999');
+      my $err = $proj->ValidateSubmission($cgi);
+      ok($err !~ m/YYYY or YYYY-YYYY/);
+    };
+
+    subtest 'nonsense' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', 1);
+      $cgi->param('actual', 'abcde');
+      my $err = $proj->ValidateSubmission($cgi);
+      ok($err =~ m/YYYY or YYYY-YYYY/);
+    };
+  };
+  
+  subtest 'pd*/cdpp must not include renewal data' => sub {
+    foreach my $attr ('pd', 'pdus') {
+      subtest $attr => sub {
+        my $cgi = CGI->new;
+        my $rights = CRMS::Entitlements->new(crms => $crms)->rights_by_attribute_reason($attr, 'cdpp')->{id};
+        $cgi->param('rights', $rights);
+        $cgi->param('renNum', 'R123');
+        $cgi->param('renDate', '4Jun23');
+        my $err = $proj->ValidateSubmission($cgi);
+        ok($err =~ m/must not include renewal info/);
+      };
+    }
+  };
+
+  subtest 'pd/cdpp must include note category and note text' => sub {
+    my $rights = CRMS::Entitlements->new(crms => $crms)->rights_by_attribute_reason('pd', 'cdpp')->{id};
+    subtest 'with both' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $rights);
+      $cgi->param('category', 'Edition');
+      $cgi->param('note', 'This is a note');
+      my $err = $proj->ValidateSubmission($cgi);
+      ok($err !~ m/must include note category and note text/);
+    };
+
+    subtest 'with neither' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $rights);
+      my $err = $proj->ValidateSubmission($cgi);
+      ok($err =~ m/must include note category and note text/);
+    };
+  };
+
+  # NOTE: this could be merged with the pd/cdpp and pdus/cdpp logic above
+  subtest 'ic/cdpp must not include renewal data' => sub {
+    my $cgi = CGI->new;
+    my $rights = CRMS::Entitlements->new(crms => $crms)->rights_by_attribute_reason('ic', 'cdpp')->{id};
+    $cgi->param('rights', $rights);
+    $cgi->param('renNum', 'R123');
+    $cgi->param('renDate', '4Jun23');
+    my $err = $proj->ValidateSubmission($cgi);
+    ok($err =~ m/must not include renewal info/);
+  };
+
+  # NOTE: this could be merged with the pd/cdpp and pdus/cdpp logic above
+  subtest 'ic/cdpp must include note category and note text' => sub {
+    my $rights = CRMS::Entitlements->new(crms => $crms)->rights_by_attribute_reason('ic', 'cdpp')->{id};
+    subtest 'with both' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $rights);
+      $cgi->param('category', 'Edition');
+      $cgi->param('note', 'This is a note');
+      my $err = $proj->ValidateSubmission($cgi);
+      ok($err !~ m/must include note category and note text/);
+    };
+
+    subtest 'with neither' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $rights);
+      my $err = $proj->ValidateSubmission($cgi);
+      ok($err =~ m/must include note category and note text/);
+    };
+  };
+
+  subtest 'und/nfi must include note category' => sub {
+    my $rights = CRMS::Entitlements->new(crms => $crms)->rights_by_attribute_reason('und', 'nfi')->{id};
+    subtest 'with category' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $rights);
+      $cgi->param('category', 'Edition');
+      my $err = $proj->ValidateSubmission($cgi);
+      ok($err !~ m/must include note category/);
+    };
+
+    subtest 'without category' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $rights);
+      my $err = $proj->ValidateSubmission($cgi);
+      ok($err =~ m/must include note category/);
+    };
+  };
+
+  subtest 'und/ren must have note category Inserts/No Renewal' => sub {
+    my $rights = CRMS::Entitlements->new(crms => $crms)->rights_by_attribute_reason('und', 'ren')->{id};
+    subtest 'with expected category' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $rights);
+      $cgi->param('category', 'Inserts/No Renewal');
+      my $err = $proj->ValidateSubmission($cgi);
+      ok($err !~ m/must have note category/);
+    };
+
+    subtest 'without expected category' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $rights);
+      $cgi->param('category', 'Edition');
+      my $err = $proj->ValidateSubmission($cgi);
+      ok($err =~ m/must have note category /);
+    };
+
+    subtest 'with no category' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $rights);
+      my $err = $proj->ValidateSubmission($cgi);
+      ok($err =~ m/must have note category /);
+    };
+  };
+
+  # FIXME: MORE TESTS NEEDED HERE
+  
+
+
+  subtest 'category without required note' => sub {
+    my $cgi = CGI->new;
+    $cgi->param('rights', 1);
+    $cgi->param('category', 'Misc');
+    my $err = $proj->ValidateSubmission($cgi);
+    ok($err =~ m/requires a note/);
+  };
+};
+
+subtest 'ExtractReviewData' => sub {
+  subtest 'with lots of data' => sub {
+    my $cgi = CGI->new;
+    $cgi->param('renNum', 'R123');
+    $cgi->param('renDate', '26Sep39');
+    $cgi->param('date', '1950');
+    $cgi->param('pub', 'on');
+    $cgi->param('crown', 'on');
+    $cgi->param('actual', '1960');
+    $cgi->param('approximate', 'on');
+    my $extracted = $proj->ExtractReviewData($cgi);
+    is($extracted->{renNum}, 'R123');
+    is($extracted->{renDate}, '26Sep39');
+    is($extracted->{date}, '1950');
+    is($extracted->{pub}, 1);
+    is($extracted->{crown}, 1);
+    is($extracted->{actual}, '1960');
+    is($extracted->{approximate}, 1);
+  };
+
+  subtest 'with very little data' => sub {
+    my $cgi = CGI->new;
+    my $extracted = $proj->ExtractReviewData($cgi);
+    is_deeply($extracted, {});
+  };
+};
+
+subtest 'extract_parameters' => sub {
+  my $cgi = CGI->new;
+  $cgi->param('rights', 1);
+  $cgi->param('renNum', "  R12345\n");
+  my $params = $proj->extract_parameters($cgi);
+  is($params->{rights}, 1, 'leaves rights unchanged');
+  is($params->{renNum}, 'R12345', 'strips whitespace');
+};
+
+subtest 'renewal_date_to_year' => sub {
+  subtest 'with a well-formed renewal date' => sub {
+    my $year = $proj->renewal_date_to_year('21Sep51');
+    is($year, '1951', 'extracts year');
+  };
+
+  subtest 'with a nonsense renewal date' => sub {
+    my $year = $proj->renewal_date_to_year('abcde');
+    is($year, '', 'returns empty string');
+  };
+};
+
+done_testing();
+
+

--- a/t/Project/SBCR.t
+++ b/t/Project/SBCR.t
@@ -15,11 +15,18 @@ use CRMS;
 use CRMS::Entitlements;
 
 my $jsonxs = JSON::XS->new->utf8->canonical(1)->pretty(0);
+# Will be used multiple times in this test suite.
+my $crms = CRMS->new();
+my $entitlements = CRMS::Entitlements->new(crms => $crms);
+# Grab the most frequently used rights ids
+my $ic_ren_rights_id = $entitlements->rights_by_attribute_reason('ic', 'ren')->{id};
+my $pd_ren_rights_id = $entitlements->rights_by_attribute_reason('pd', 'ren')->{id};
+my $ic_cdpp_rights_id = $entitlements->rights_by_attribute_reason('ic', 'cdpp')->{id};
+my $und_nfi_rights_id = $entitlements->rights_by_attribute_reason('und', 'nfi')->{id};
+my $und_ren_rights_id = $entitlements->rights_by_attribute_reason('und', 'ren')->{id};
 
 require_ok($ENV{'SDRROOT'}. '/crms/cgi/Project/SBCR.pm');
 
-my $crms = CRMS->new();
-# TODO: Project::for_name would be a much nicer way to do this.
 my $sql = 'SELECT id FROM projects WHERE name="SBCR"';
 my $project_id = $crms->SimpleSqlGet($sql);
 my $proj = SBCR->new(crms => $crms, id => $project_id);
@@ -41,56 +48,142 @@ subtest 'SBCR::ValidateSubmission' => sub {
     ok($err =~ m/rights\/reason combination/);
   };
 
-  subtest 'ADD/pub date with too many digits' => sub {
-    my $cgi = CGI->new;
-    $cgi->param('rights', 1);
-    $cgi->param('date', '12345');
-    my $err = $proj->ValidateSubmission($cgi);
-    ok($err =~ m/decimal digits/);
+  subtest 'date must be only decimal digits' => sub {
+    subtest 'acceptable inputs' => sub {
+      foreach my $date ('1234', '-1234') {
+        my $cgi = CGI->new;
+        $cgi->param('rights', 1);
+        $cgi->param('date', $date);
+        my $err = $proj->ValidateSubmission($cgi);
+        ok($err !~ m/date must be only decimal digits/);
+      }
+    };
+
+    subtest 'unacceptable inputs' => sub {
+      foreach my $date ('12345', '-12345', 'c.1950') {
+        my $cgi = CGI->new;
+        $cgi->param('rights', 1);
+        $cgi->param('date', $date);
+        my $err = $proj->ValidateSubmission($cgi);
+        ok($err =~ m/date must be only decimal digits/);
+      }
+    };
+
+    subtest 'no date submitted' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', 1);
+      my $err = $proj->ValidateSubmission($cgi);
+      ok($err !~ m/date must be only decimal digits/);
+    };
   };
 
-  subtest 'pd/add with no date' => sub {
-    my $cgi = CGI->new;
-    my $rights = CRMS::Entitlements->new(crms => $crms)->rights_by_attribute_reason('pd', 'add')->{id};
-    $cgi->param('rights', $rights);
-    my $err = $proj->ValidateSubmission($cgi);
-    ok($err =~ m/numeric year/);
+  subtest '*/add and */exp must include a numeric year' => sub {
+    foreach my $id (keys %{$entitlements->{rights}}) {
+      my $rights = $entitlements->{rights}->{$id};
+      if ($rights->{reason_name} eq 'add' || $rights->{reason_name} eq 'exp') {
+        subtest "$rights->{name} with date" => sub {
+          my $cgi = CGI->new;
+          $cgi->param('rights', $rights->{id});
+          $cgi->param('date', 1957);
+          my $err = $proj->ValidateSubmission($cgi);
+          ok($err !~ m/must include a numeric year/);
+        };
+
+        subtest "$rights->{name} without date" => sub {
+          my $cgi = CGI->new;
+          $cgi->param('rights', $rights->{id});
+          #$cgi->param('date', 1957);
+          my $err = $proj->ValidateSubmission($cgi);
+          ok($err =~ m/must include a numeric year/);
+        };
+      } else {
+        subtest "$rights->{name} with date" => sub {
+          my $cgi = CGI->new;
+          $cgi->param('rights', $rights->{id});
+          $cgi->param('date', 1957);
+          my $err = $proj->ValidateSubmission($cgi);
+          ok($err !~ m/must include a numeric year/);
+        };
+      }
+    }
   };
 
-  subtest 'pd/exp with no date' => sub {
-    my $cgi = CGI->new;
-    my $rights = CRMS::Entitlements->new(crms => $crms)->rights_by_attribute_reason('pd', 'exp')->{id};
-    $cgi->param('rights', $rights);
-    my $err = $proj->ValidateSubmission($cgi);
-    ok($err =~ m/numeric year/);
+  subtest 'renewal ... has expired: volume is pd' => sub {
+    subtest 'ic/ren with nonexpired renewal' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $ic_ren_rights_id);
+      $cgi->param('renNum', 'R123');
+      $cgi->param('renDate', '4Jun63');
+      my $err = $proj->ValidateSubmission($cgi);
+      ok($err !~ m/renewal .*? has expired: volume is pd/);
+    };
+
+    subtest 'ic/ren with expired renewal date' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $ic_ren_rights_id);
+      $cgi->param('renNum', 'R123');
+      $cgi->param('renDate', '4Jun23');
+      my $err = $proj->ValidateSubmission($cgi);
+      ok($err =~ m/renewal .*? has expired: volume is pd/);
+    };
+    
+    subtest 'ic/ren with unparseable renewal date' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $ic_ren_rights_id);
+      $cgi->param('renNum', 'R123');
+      $cgi->param('renDate', 'unparseable');
+      my $err = $proj->ValidateSubmission($cgi);
+      ok($err !~ m/renewal .*? has expired: volume is pd/);
+    };
+
+    subtest 'ic/ren with no renewal date' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $ic_ren_rights_id);
+      $cgi->param('renNum', 'R123');
+      my $err = $proj->ValidateSubmission($cgi);
+      ok($err !~ m/renewal .*? has expired: volume is pd/);
+    };
+
+    subtest 'not ic/ren' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $pd_ren_rights_id);
+      $cgi->param('renNum', 'R123');
+      $cgi->param('renDate', '4Jun23');
+      my $err = $proj->ValidateSubmission($cgi);
+      ok($err !~ m/renewal .*? has expired: volume is pd/);
+    };
   };
 
-  subtest 'ic/ren with expired renewal' => sub {
+  subtest 'ic/ren must include renewal id and renewal date' => sub {
     my $cgi = CGI->new;
-    my $rights = CRMS::Entitlements->new(crms => $crms)->rights_by_attribute_reason('ic', 'ren')->{id};
-    $cgi->param('rights', $rights);
-    $cgi->param('renNum', 'R123');
-    $cgi->param('renDate', '4Jun23');
+    $cgi->param('rights', $ic_ren_rights_id);
     my $err = $proj->ValidateSubmission($cgi);
-    ok($err =~ m/expired/);
+    ok($err =~ m/must include renewal id and renewal date/);
   };
 
-  subtest 'ic/ren with no renewal data' => sub {
-    my $cgi = CGI->new;
-    my $rights = CRMS::Entitlements->new(crms => $crms)->rights_by_attribute_reason('ic', 'ren')->{id};
-    $cgi->param('rights', $rights);
-    my $err = $proj->ValidateSubmission($cgi);
-    ok($err =~ m/renewal id/);
-  };
+  subtest 'pd/ren should not include renewal info' => sub {
+    subtest 'without renewal info' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $pd_ren_rights_id);
+      my $err = $proj->ValidateSubmission($cgi);
+      ok($err !~ m/should not include renewal info/);
+    };
 
-  subtest 'pd/ren with renewal data' => sub {
-    my $cgi = CGI->new;
-    my $rights = CRMS::Entitlements->new(crms => $crms)->rights_by_attribute_reason('pd', 'ren')->{id};
-    $cgi->param('rights', $rights);
-    $cgi->param('renNum', 'R123');
-    $cgi->param('renDate', '4Jun23');
-    my $err = $proj->ValidateSubmission($cgi);
-    ok($err =~ m/should not include renewal info/);
+    subtest 'with renNum' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $pd_ren_rights_id);
+      $cgi->param('renNum', 'R123');
+      my $err = $proj->ValidateSubmission($cgi);
+      ok($err =~ m/should not include renewal info/);
+    };
+
+    subtest 'with renDate' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $pd_ren_rights_id);
+      $cgi->param('renDate', '4Jun23');
+      my $err = $proj->ValidateSubmission($cgi);
+      ok($err =~ m/should not include renewal info/);
+    };
   };
 
   subtest 'actual publication date' => sub {
@@ -118,23 +211,37 @@ subtest 'SBCR::ValidateSubmission' => sub {
       ok($err =~ m/YYYY or YYYY-YYYY/);
     };
   };
-  
+
   subtest 'pd*/cdpp must not include renewal data' => sub {
     foreach my $attr ('pd', 'pdus') {
-      subtest $attr => sub {
+      my $rights = $entitlements->rights_by_attribute_reason($attr, 'cdpp')->{id};
+      subtest "$attr with renewal number" => sub {
         my $cgi = CGI->new;
-        my $rights = CRMS::Entitlements->new(crms => $crms)->rights_by_attribute_reason($attr, 'cdpp')->{id};
         $cgi->param('rights', $rights);
         $cgi->param('renNum', 'R123');
+        my $err = $proj->ValidateSubmission($cgi);
+        ok($err =~ m/must not include renewal info/);
+      };
+
+      subtest "$attr with renewal date" => sub {
+        my $cgi = CGI->new;
+        $cgi->param('rights', $rights);
         $cgi->param('renDate', '4Jun23');
         my $err = $proj->ValidateSubmission($cgi);
         ok($err =~ m/must not include renewal info/);
+      };
+
+      subtest "$attr without renewal data" => sub {
+        my $cgi = CGI->new;
+        $cgi->param('rights', $rights);
+        my $err = $proj->ValidateSubmission($cgi);
+        ok($err !~ m/must not include renewal info/);
       };
     }
   };
 
   subtest 'pd/cdpp must include note category and note text' => sub {
-    my $rights = CRMS::Entitlements->new(crms => $crms)->rights_by_attribute_reason('pd', 'cdpp')->{id};
+    my $rights = $entitlements->rights_by_attribute_reason('pd', 'cdpp')->{id};
     subtest 'with both' => sub {
       my $cgi = CGI->new;
       $cgi->param('rights', $rights);
@@ -142,6 +249,14 @@ subtest 'SBCR::ValidateSubmission' => sub {
       $cgi->param('note', 'This is a note');
       my $err = $proj->ValidateSubmission($cgi);
       ok($err !~ m/must include note category and note text/);
+    };
+
+    subtest 'with note only' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $rights);
+      $cgi->param('note', 'This is a note');
+      my $err = $proj->ValidateSubmission($cgi);
+      ok($err =~ m/must include note category and note text/);
     };
 
     subtest 'with neither' => sub {
@@ -154,40 +269,54 @@ subtest 'SBCR::ValidateSubmission' => sub {
 
   # NOTE: this could be merged with the pd/cdpp and pdus/cdpp logic above
   subtest 'ic/cdpp must not include renewal data' => sub {
-    my $cgi = CGI->new;
-    my $rights = CRMS::Entitlements->new(crms => $crms)->rights_by_attribute_reason('ic', 'cdpp')->{id};
-    $cgi->param('rights', $rights);
-    $cgi->param('renNum', 'R123');
-    $cgi->param('renDate', '4Jun23');
-    my $err = $proj->ValidateSubmission($cgi);
-    ok($err =~ m/must not include renewal info/);
+    subtest 'with renewal number' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $ic_cdpp_rights_id);
+      $cgi->param('renNum', 'R123');
+      my $err = $proj->ValidateSubmission($cgi);
+      ok($err =~ m/must not include renewal info/);
+    };
+    
+    subtest 'with renewal date' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $ic_cdpp_rights_id);
+      $cgi->param('renDate', '4Jun23');
+      my $err = $proj->ValidateSubmission($cgi);
+      ok($err =~ m/must not include renewal info/);
+    };
   };
 
   # NOTE: this could be merged with the pd/cdpp and pdus/cdpp logic above
   subtest 'ic/cdpp must include note category and note text' => sub {
-    my $rights = CRMS::Entitlements->new(crms => $crms)->rights_by_attribute_reason('ic', 'cdpp')->{id};
     subtest 'with both' => sub {
       my $cgi = CGI->new;
-      $cgi->param('rights', $rights);
+      $cgi->param('rights', $ic_cdpp_rights_id);
       $cgi->param('category', 'Edition');
       $cgi->param('note', 'This is a note');
       my $err = $proj->ValidateSubmission($cgi);
       ok($err !~ m/must include note category and note text/);
     };
 
+    subtest 'with note only' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $ic_cdpp_rights_id);
+      $cgi->param('note', 'This is a note');
+      my $err = $proj->ValidateSubmission($cgi);
+      ok($err =~ m/must include note category and note text/);
+    };
+
     subtest 'with neither' => sub {
       my $cgi = CGI->new;
-      $cgi->param('rights', $rights);
+      $cgi->param('rights', $ic_cdpp_rights_id);
       my $err = $proj->ValidateSubmission($cgi);
       ok($err =~ m/must include note category and note text/);
     };
   };
 
   subtest 'und/nfi must include note category' => sub {
-    my $rights = CRMS::Entitlements->new(crms => $crms)->rights_by_attribute_reason('und', 'nfi')->{id};
     subtest 'with category' => sub {
       my $cgi = CGI->new;
-      $cgi->param('rights', $rights);
+      $cgi->param('rights', $und_nfi_rights_id);
       $cgi->param('category', 'Edition');
       my $err = $proj->ValidateSubmission($cgi);
       ok($err !~ m/must include note category/);
@@ -195,49 +324,131 @@ subtest 'SBCR::ValidateSubmission' => sub {
 
     subtest 'without category' => sub {
       my $cgi = CGI->new;
-      $cgi->param('rights', $rights);
+      $cgi->param('rights', $und_nfi_rights_id);
       my $err = $proj->ValidateSubmission($cgi);
       ok($err =~ m/must include note category/);
     };
   };
 
   subtest 'und/ren must have note category Inserts/No Renewal' => sub {
-    my $rights = CRMS::Entitlements->new(crms => $crms)->rights_by_attribute_reason('und', 'ren')->{id};
     subtest 'with expected category' => sub {
       my $cgi = CGI->new;
-      $cgi->param('rights', $rights);
+      $cgi->param('rights', $und_ren_rights_id);
       $cgi->param('category', 'Inserts/No Renewal');
       my $err = $proj->ValidateSubmission($cgi);
-      ok($err !~ m/must have note category/);
+      ok($err !~ m/mmust have note category Inserts\/No Renewal/);
     };
 
     subtest 'without expected category' => sub {
       my $cgi = CGI->new;
-      $cgi->param('rights', $rights);
+      $cgi->param('rights', $und_ren_rights_id);
       $cgi->param('category', 'Edition');
       my $err = $proj->ValidateSubmission($cgi);
-      ok($err =~ m/must have note category /);
+      ok($err =~ m/must have note category Inserts\/No Renewal/);
     };
 
     subtest 'with no category' => sub {
       my $cgi = CGI->new;
-      $cgi->param('rights', $rights);
+      $cgi->param('rights', $und_ren_rights_id);
       my $err = $proj->ValidateSubmission($cgi);
       ok($err =~ m/must have note category /);
     };
   };
-
-  # FIXME: MORE TESTS NEEDED HERE
   
+  subtest 'Inserts/No Renewal category is only used with und/ren' => sub {
+    subtest 'with expected rights' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $und_ren_rights_id);
+      $cgi->param('category', 'Inserts/No Renewal');
+      my $err = $proj->ValidateSubmission($cgi);
+      ok($err !~ m/must have rights code/);
+    };
 
-
-  subtest 'category without required note' => sub {
-    my $cgi = CGI->new;
-    $cgi->param('rights', 1);
-    $cgi->param('category', 'Misc');
-    my $err = $proj->ValidateSubmission($cgi);
-    ok($err =~ m/requires a note/);
+    subtest 'without expected rights' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $und_nfi_rights_id);
+      $cgi->param('category', 'Inserts/No Renewal');
+      my $err = $proj->ValidateSubmission($cgi);
+      ok($err =~ m/must have rights code/);
+    };
   };
+
+  subtest "note optionality" => sub {
+    my $note_required = $crms->SimpleSqlGet('SELECT name FROM categories WHERE need_note=1 AND interface=1 AND restricted IS NULL');
+    my $note_optional = $crms->SimpleSqlGet('SELECT name FROM categories WHERE need_note=0 AND interface=1 AND restricted IS NULL');
+    subtest 'category without required note' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', 1);
+      $cgi->param('category', $note_required);
+      my $err = $proj->ValidateSubmission($cgi);
+      ok($err =~ m/requires a note/);
+    };
+
+    subtest 'category with required note' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', 1);
+      $cgi->param('category', $note_required);
+      $cgi->param('note', 'This is a required note');
+      my $err = $proj->ValidateSubmission($cgi);
+      ok($err !~ m/requires a note/);
+    };
+
+    subtest 'category without optional note' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', 1);
+      $cgi->param('category', $note_optional);
+      my $err = $proj->ValidateSubmission($cgi);
+      ok($err !~ m/requires a note/);
+    };
+
+    subtest 'category with required note' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', 1);
+      $cgi->param('category', $note_optional);
+      $cgi->param('note', 'This is an optional note');
+      my $err = $proj->ValidateSubmission($cgi);
+      ok($err !~ m/requires a note/);
+    };
+  };
+
+  subtest 'must include a category if there is a note' => sub {
+    subtest 'note with category' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', 1);
+      $cgi->param('note', 'This is a note');
+      $cgi->param('category', 'Misc');
+      my $err = $proj->ValidateSubmission($cgi);
+      ok($err !~ m/must include a category/);
+    };
+
+    subtest 'note without category' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', 1);
+      $cgi->param('note', 'This is a note');
+      my $err = $proj->ValidateSubmission($cgi);
+      ok($err =~ m/must include a category/);
+    };
+  };
+  
+  subtest 'Not Government category requires und/NFI' => sub {
+    subtest 'Not Government category with und/nfi' => sub {
+      my $rights = $entitlements->rights_by_attribute_reason('und', 'nfi')->{id};
+      my $cgi = CGI->new;
+      $cgi->param('rights', $rights);
+      $cgi->param('category', 'Not Government');
+      my $err = $proj->ValidateSubmission($cgi);
+      ok($err !~ m/Not Government category requires/);
+    };
+
+    subtest 'Not Government category without und/nfi' => sub {
+      my $cgi = CGI->new;
+      $cgi->param('rights', $ic_ren_rights_id);
+      $cgi->param('category', 'Not Government');
+      my $err = $proj->ValidateSubmission($cgi);
+      ok($err =~ m/Not Government category requires/);
+    };
+  };
+  # End of ValidateSubmission subtest
 };
 
 subtest 'ExtractReviewData' => sub {
@@ -268,22 +479,52 @@ subtest 'ExtractReviewData' => sub {
 };
 
 subtest 'FormatReviewData' => sub {
-  my $data = {
-    renNum => 'R123',
-    renDate => '26Sep39',
-    date => '1950',
-    pub => 1,
-    crown => 1,
-    actual => '1960',
-    approximate => 1
+  subtest 'with lots of data' => sub {
+    my $data = {
+      renNum => 'R123',
+      renDate => '26Sep39',
+      date => '1950',
+      pub => 0,
+      crown => 1,
+      actual => '1960',
+      approximate => 1
+    };
+    my $json = $jsonxs->encode($data);
+    my $format = $proj->FormatReviewData(1, $json);
+    ok($format->{format} =~ /Renewal/);
+    ok($format->{format} =~ /ADD/);
+    ok($format->{format} !~ /<strong>Pub/);
+    ok($format->{format} =~ /Crown/);
+    ok($format->{format} =~ /Actual/);
+    is($format->{id}, 1);
   };
-  my $json = $jsonxs->encode($data);
-  my $format = $proj->FormatReviewData(1, $json);
-  ok($format->{format} =~ /renewal/i);
-  ok($format->{format} =~ /pub/i);
-  ok($format->{format} =~ /crown/i);
-  ok($format->{format} =~ /actual/i);
-  is($format->{id}, 1);
+
+  subtest 'with a little data' => sub {
+    my $data = {
+      date => '1960',
+      pub => 1
+    };
+    my $json = $jsonxs->encode($data);
+    my $format = $proj->FormatReviewData(1, $json);
+    ok($format->{format} !~ /Renewal/);
+    ok($format->{format} !~ /ADD/);
+    ok($format->{format} =~ /<strong>Pub/);
+    ok($format->{format} !~ /Crown/);
+    ok($format->{format} !~ /Actual/);
+    is($format->{id}, 1);
+  };
+  
+  subtest 'with no data' => sub {
+    my $data = {};
+    my $json = $jsonxs->encode($data);
+    my $format = $proj->FormatReviewData(1, $json);
+    ok($format->{format} !~ /Renewal/);
+    ok($format->{format} !~ /ADD/);
+    ok($format->{format} !~ /<strong>Pub/);
+    ok($format->{format} !~ /Crown/);
+    ok($format->{format} !~ /Actual/);
+    is($format->{id}, 1);
+  };
 };
 
 subtest 'extract_parameters' => sub {
@@ -293,6 +534,25 @@ subtest 'extract_parameters' => sub {
   my $params = $proj->extract_parameters($cgi);
   is($params->{rights}, 1, 'leaves rights unchanged');
   is($params->{renNum}, 'R12345', 'strips whitespace');
+};
+
+subtest 'format_renewal_data' => sub {
+  subtest 'with no data' => sub {
+    ok(length $proj->format_renewal_data(undef, undef) == 0);
+  };
+
+  subtest 'with only renNum' => sub {
+    ok($proj->format_renewal_data('R123', undef) =~ m/R123/);
+  };
+
+  subtest 'with only renDate' => sub {
+    ok($proj->format_renewal_data(undef, '1Oct51') =~ m/1Oct51/);
+  };
+
+  subtest 'with both renNum and renDate' => sub {
+    ok($proj->format_renewal_data('R123', '1Oct51') =~ m/R123/);
+    ok($proj->format_renewal_data('R123', '1Oct51') =~ m/1Oct51/);
+  };
 };
 
 subtest 'renewal_date_to_year' => sub {

--- a/t/Project/SBCR.t
+++ b/t/Project/SBCR.t
@@ -6,6 +6,7 @@ use utf8;
 
 use CGI;
 use Data::Dumper;
+use JSON::XS;
 use Test::More;
 
 use lib $ENV{'SDRROOT'} . '/crms/cgi';
@@ -13,6 +14,7 @@ use lib $ENV{'SDRROOT'} . '/crms/lib';
 use CRMS;
 use CRMS::Entitlements;
 
+my $jsonxs = JSON::XS->new->utf8->canonical(1)->pretty(0);
 
 require_ok($ENV{'SDRROOT'}. '/crms/cgi/Project/SBCR.pm');
 
@@ -263,6 +265,25 @@ subtest 'ExtractReviewData' => sub {
     my $extracted = $proj->ExtractReviewData($cgi);
     is_deeply($extracted, {});
   };
+};
+
+subtest 'FormatReviewData' => sub {
+  my $data = {
+    renNum => 'R123',
+    renDate => '26Sep39',
+    date => '1950',
+    pub => 1,
+    crown => 1,
+    actual => '1960',
+    approximate => 1
+  };
+  my $json = $jsonxs->encode($data);
+  my $format = $proj->FormatReviewData(1, $json);
+  ok($format->{format} =~ /renewal/i);
+  ok($format->{format} =~ /pub/i);
+  ok($format->{format} =~ /crown/i);
+  ok($format->{format} =~ /actual/i);
+  is($format->{id}, 1);
 };
 
 subtest 'extract_parameters' => sub {

--- a/t/lib/CRMS/Entitlements.t
+++ b/t/lib/CRMS/Entitlements.t
@@ -13,12 +13,15 @@ use CRMS::Entitlements;
 
 my $crms = CRMS->new;
 
-subtest '::new' => sub {
-  my $rights = CRMS::Entitlements->new(crms => $crms);
-  isa_ok($rights, 'CRMS::Entitlements');
-  
+#$CRMS::Entitlements::ONE_TRUE_ENTITLEMENTS = undef;
+subtest 'new' => sub {
   subtest 'Missing CRMS' => sub {
     dies_ok { CRMS::Entitlements->new; };
+  };
+
+  subtest 'CRMS supplied' => sub {
+    my $rights = CRMS::Entitlements->new(crms => $crms, reinit => 1);
+    isa_ok($rights, 'CRMS::Entitlements');
   };
 };
 
@@ -34,7 +37,7 @@ subtest 'rights_by_attribute_reason' => sub {
     is($rights->{reason_name}, 'ren');
     is($rights->{name}, 'ic/ren');
   };
-  
+
   subtest 'with names' => sub {
     my $rights = CRMS::Entitlements->new(crms => $crms)->rights_by_attribute_reason('ic', 'ren');
     is($rights->{attribute_name}, 'ic');

--- a/t/lib/CRMS/Entitlements.t
+++ b/t/lib/CRMS/Entitlements.t
@@ -1,0 +1,66 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::Exception;
+use Test::More;
+
+use lib $ENV{'SDRROOT'} . '/crms/cgi';
+use lib $ENV{'SDRROOT'} . '/crms/lib';
+use CRMS;
+use CRMS::Entitlements;
+
+my $crms = CRMS->new;
+
+subtest '::new' => sub {
+  my $rights = CRMS::Entitlements->new(crms => $crms);
+  isa_ok($rights, 'CRMS::Entitlements');
+  
+  subtest 'Missing CRMS' => sub {
+    dies_ok { CRMS::Entitlements->new; };
+  };
+};
+
+subtest 'rights_by_id' => sub {
+  my $rights = CRMS::Entitlements->new(crms => $crms)->rights_by_id(5);
+  is($rights->{id}, 5);
+};
+
+subtest 'rights_by_attribute_reason' => sub {
+  subtest 'with ids' => sub {
+    my $rights = CRMS::Entitlements->new(crms => $crms)->rights_by_attribute_reason(2, 7);
+    is($rights->{attribute_name}, 'ic');
+    is($rights->{reason_name}, 'ren');
+    is($rights->{name}, 'ic/ren');
+  };
+  
+  subtest 'with names' => sub {
+    my $rights = CRMS::Entitlements->new(crms => $crms)->rights_by_attribute_reason('ic', 'ren');
+    is($rights->{attribute_name}, 'ic');
+    is($rights->{reason_name}, 'ren');
+    is($rights->{name}, 'ic/ren');
+  };
+};
+
+subtest 'attribute_by_id' => sub {
+  my $attr = CRMS::Entitlements->new(crms => $crms)->attribute_by_id(1);
+  is($attr->{name}, 'pd', 'attribute 1 is named "pd"');
+};
+
+subtest 'attribute_by_name' => sub {
+  my $attr = CRMS::Entitlements->new(crms => $crms)->attribute_by_name('pd');
+  is($attr->{id}, 1, 'attribute "pd" is id=1');
+};
+
+subtest 'reason_by_id' => sub {
+  my $reason = CRMS::Entitlements->new(crms => $crms)->reason_by_id(1);
+  is($reason->{name}, 'bib', 'reason 1 is named "bib"');
+};
+
+subtest 'reason_by_name' => sub {
+  my $reason = CRMS::Entitlements->new(crms => $crms)->reason_by_name('bib');
+  is($reason->{id}, 1, 'reason "bib" is id=1');
+};
+
+done_testing();

--- a/web/css/review.css
+++ b/web/css/review.css
@@ -207,11 +207,22 @@ table.ReviewError {
   font-size:12px;
 }
 
+/*
+  FIXME: remove the #Notes styles when all review interfaces are using .note-container class
+*/
 #Notes {
   margin-left:10px;
 }
 
 #Notes textarea {
+  margin-block-start: 5px;
+}
+
+.note-container {
+  margin-left:10px;
+}
+
+.note-container textarea {
   margin-block-start: 5px;
 }
 

--- a/web/js/review.js
+++ b/web/js/review.js
@@ -135,7 +135,7 @@ function ajaxURL(target) {
 function togglePredictionLoader(display) {
   var img = document.getElementById("predictionLoader");
   if (img) {
-    img.style.display = display ? "block" : "none";
+    img.style.display = display ? "inline-block" : "none";
   }
 }
 

--- a/web/js/review.js
+++ b/web/js/review.js
@@ -51,12 +51,16 @@ function popRenewalDate()
     {
       var icren = document.getElementById('ICREN');
       var pdusren = document.getElementById('PDUSREN');
+      // TODO: this is a really clunky way of making the mapping from rights name ->
+      // rights id (and ultimately the radio button with that id value) available to JavaScript.
+      // Ideally, review.tt should query Entitlements.pm and construct JSON with name -> id map
+      // as a global variable.
       var icrenButton, pdusrenButton;
       if (icren)
       {
         icrenButton = document.getElementById("r" + icren.title);
       }
-      if (icren)
+      if (pdusren)
       {
         pdusrenButton = document.getElementById("r" + pdusren.title);
       }


### PR DESCRIPTION
The SBCR UI is a combination of the Core and Crown Copyright projects. No attempt has been made to reduce duplication between the new code and the existing UI components (*.tt bits), since we don't have sufficient test coverage, in particular no way to Playwright the thing.

The new `Project::SBCR` subclass has 100% test coverage, most of that being in the `ValidateSubmission` method which does a number of checks on user-entered review data. Many of these were written (based on checks in other projects) and not needed for SBCR so they are applied toward better coverage in Project.t (which holds the default set of validations for monographs/state gov docs projects) mostly. More could be done, either by copying the tests to other projects, or by extracting out common validations to the `Project` class. That's out of scope.

CRMS::Entitlements (also 100% under test) was added because the `CRMS.pm` methods are gross wrappers around SQL-as-API and I wanted something not horrible for the `SBCR.pm` tests. The comments indicate this may be a temporary class name because `CRMS::Rights` is currently taken... but I have to confess `Entitlements` is growing on me.

The `UNIQUE` constraint on `crms.rights.{attr/reason}` has already been applied in production and htdev.