### PR TITLE
ETT-61 Exclude */man items from newyear.pl

### DIFF
--- a/bin/newyear.pl
+++ b/bin/newyear.pl
@@ -18,6 +18,7 @@ $Term::ANSIColor::AUTORESET = 1;
 use Data::Dumper;
 
 use CRMS;
+use CRMS::NewYear;
 use CRMS::RightsPredictor;
 
 binmode(STDOUT, ':encoding(UTF-8)');
@@ -83,6 +84,7 @@ my $crms = CRMS->new(
     verbose  => $verbose,
     instance => $instance
 );
+my $new_year = CRMS::NewYear->new;
 
 $verbose = 0 unless defined $verbose;
 print "Verbosity $verbose\n" if $verbose;
@@ -153,7 +155,7 @@ sub ProcessCommonwealthProject {
       next;
     }
     my ($acurr, $rcurr, $src, $usr, $timecurr, $note) = @{$rq->[0]};
-    next if $acurr eq 'pd' or $acurr =~ m/^cc/;
+    next if !$new_year->are_rights_in_scope($acurr, $rcurr);
     my $record = $crms->GetMetadata($id);
     next unless defined $record;
     my $rp = CRMS::RightsPredictor->new(record => $record);
@@ -259,6 +261,7 @@ sub ProcessPubDateProject
       $date =~ s/^\s+|\s+$//g;
       $dates{$date} = $date if defined $date;
     }
+    # FIXME: $date_str is unused
     my $date_str = join ', ', keys %dates;
     if (scalar keys %dates == 1) {
       my $rq = $crms->RightsQuery($id, 1);
@@ -267,7 +270,7 @@ sub ProcessPubDateProject
         next;
       }
       my ($acurr, $rcurr, $src, $usr, $timecurr, $note) = @{$rq->[0]};
-      next if $acurr eq 'pd' or $acurr =~ m/^cc/;
+      next if !$new_year->are_rights_in_scope($acurr, $rcurr);
       my $record = $crms->GetMetadata($id);
       if (!defined $record) {
         #print RED "Unable to get metadata for $id\n";
@@ -318,7 +321,7 @@ sub ProcessCrownCopyrightProject {
       next;
     }
     my ($acurr, $rcurr, $src, $usr, $timecurr, $note) = @{$rq->[0]};
-    next if $acurr eq 'pd' or $acurr =~ m/^cc/;
+    next if !$new_year->are_rights_in_scope($acurr, $rcurr);
     my $record = $crms->GetMetadata($id);
     next unless defined $record;
     my $gid = $row->[1];

--- a/bin/newyear.pl
+++ b/bin/newyear.pl
@@ -171,7 +171,7 @@ sub ProcessCommonwealthProject {
     my %predictions;
     foreach my $row2 (@{$ref2}) {
       my $note = $row2->[0] || '';
-      my $user = $row2->[1];
+      my $user = $row2->[1]; # FIXME: not used
       my $data = $row2->[2];
       $data = $jsonxs->decode($data);
       my $date = $data->{'date'};
@@ -337,7 +337,7 @@ sub ProcessCrownCopyrightProject {
     my %dates = ();
     foreach my $row2 (@{$ref2}) {
       my $note = $row2->[0] || '';
-      my $user = $row2->[1];
+      my $user = $row2->[1]; # FIXME: not used
       my $data = $row2->[2];
       $data = $jsonxs->decode($data);
       my $date = $data->{'date'};

--- a/bin/newyear.pl
+++ b/bin/newyear.pl
@@ -157,7 +157,11 @@ sub ProcessCommonwealthProject {
     my ($acurr, $rcurr, $src, $usr, $timecurr, $note) = @{$rq->[0]};
     next if !$new_year->are_rights_in_scope($acurr, $rcurr);
     my $record = $crms->GetMetadata($id);
-    next unless defined $record;
+    if (!defined $record) {
+      $crms->ClearErrors;
+      print RED "Unable to get metadata for $id\n" if $verbose;
+      next;
+    }
     my $rp = CRMS::RightsPredictor->new(record => $record);
     my $gid = $row->[1];
     my $time = $row->[2];
@@ -273,7 +277,8 @@ sub ProcessPubDateProject
       next if !$new_year->are_rights_in_scope($acurr, $rcurr);
       my $record = $crms->GetMetadata($id);
       if (!defined $record) {
-        #print RED "Unable to get metadata for $id\n";
+        $crms->ClearErrors;
+        print RED "Unable to get metadata for $id\n" if $verbose;
         next;
       }
       my $date = (keys %dates)[0];
@@ -323,7 +328,11 @@ sub ProcessCrownCopyrightProject {
     my ($acurr, $rcurr, $src, $usr, $timecurr, $note) = @{$rq->[0]};
     next if !$new_year->are_rights_in_scope($acurr, $rcurr);
     my $record = $crms->GetMetadata($id);
-    next unless defined $record;
+    if (!defined $record) {
+      $crms->ClearErrors;
+      print RED "Unable to get metadata for $id\n" if $verbose;
+      next;
+    }
     my $gid = $row->[1];
     my $time = $row->[2];
     $seen{$id} = 1;
@@ -394,8 +403,11 @@ sub ProcessKeioICUS {
     my $current_rights = $crms->GetCurrentRights($id);
     next if $current_rights !~ m/^icus/;
     my $record = $crms->GetMetadata($id);
-    print BOLD RED "Can't get metadata for $id\n" unless defined $record;
-    next unless defined $record;
+    if (!defined $record) {
+      $crms->ClearErrors;
+      print RED "Unable to get metadata for $id\n" if $verbose;
+      next;
+    }
     SubmitNewYearReview($id, 'pd', 'add', 'Keio', $record, '', '');
   }
 }

--- a/lib/CRMS/NewYear.pm
+++ b/lib/CRMS/NewYear.pm
@@ -100,7 +100,7 @@ sub choose_rights_prediction {
     ($a->{value} || 0) < ($b->{value} || 0) ? $a : $b;
   } @values;
 
-  # Bail out if there were no predictions, or if the best we can do is undef/ic
+  # Bail out if there were no predictions, or if the best we can do is ic or "anything else"
   if (!$min || !$min->{value}) {
     return;
   }

--- a/lib/CRMS/NewYear.pm
+++ b/lib/CRMS/NewYear.pm
@@ -71,6 +71,10 @@ sub are_rights_in_scope {
 # |-----------|
 #
 # In a nutshell: choose minimum prediction and return it if it is greater than current rights
+#
+# Note: there are rare but attested cases where we have legit pd/add and pd/exp predictions
+# and the unordered hash implementation will, if pd is chosen, choose one at random.
+# The old implementation did the same thing. KH has signed off on this as "don't care."
 sub choose_rights_prediction {
   my $self        = shift;
   my $attribute   = shift; # current rights attr string

--- a/lib/CRMS/NewYear.pm
+++ b/lib/CRMS/NewYear.pm
@@ -1,0 +1,43 @@
+package CRMS::NewYear;
+
+# A utility package containing logic that relates to the new year Public Domain Day
+# rollover of rights.
+
+use strict;
+use warnings;
+use utf8;
+
+use Data::Dumper;
+
+sub new {
+  my $class = shift;
+
+  my $self = { @_ };
+  bless($self, $class);
+  return $self;
+}
+
+# Are the passed-in current rights "attribute" and "reason" names in scope for
+# PDD rollover? This excludes pd and CC items, because there's nothing more to be done.
+# It also excludes */{con, del, man, pvt, supp} items, because CRMS can't override them
+# and there is no point in reporting them.
+sub are_rights_in_scope {
+  my $self      = shift;
+  my $attribute = shift;
+  my $reason    = shift;
+
+  if (
+    $attribute eq 'pd' ||
+    $attribute =~ m/^cc/ ||
+    $reason eq 'con' ||
+    $reason eq 'del' ||
+    $reason eq 'man' ||
+    $reason eq 'pvt' ||
+    $reason eq 'supp'
+  ) {
+    return;
+  }
+  return 1;
+}
+
+1;

--- a/lib/CRMS/NewYear.pm
+++ b/lib/CRMS/NewYear.pm
@@ -8,6 +8,7 @@ use warnings;
 use utf8;
 
 use Data::Dumper;
+use List::Util qw();
 
 sub new {
   my $class = shift;
@@ -38,6 +39,78 @@ sub are_rights_in_scope {
     return;
   }
   return 1;
+}
+
+# Given a set of rights predictions that might reasonably be made based on reviewer data,
+# in the form of a hashref of { "pd/add" => 1, "ic/add" => 1, ... } and the current attribute
+# name, calculate the most restrictive attribute among the predictions, provided that attribute
+# would be a "step up" from the current one (in terms of permissiveness).
+# For example, if there is a "pdus" and an "icus" prediction, only consider "icus".
+# And then only return it as the new rights if it would make the current rights less restrictive.
+#
+# Scenario where no prediction is allowed:
+# |-----------|
+# | 3   pd    |  <----- PREDICTION (cannot use, it is not the most restrictive)
+# |-----------|
+# | 2  pdus   |  <----- CURRENT RIGHTS
+# |-----------|
+# | 1  icus   |  <----- PREDICTION (cannot use, would be a downgrade)
+# |-----------|
+# | 0   ic    |
+# |-----------|
+#
+# Scenario where we do want a new prediction:
+# |-----------|
+# | 3   pd    |  <----- PREDICTION (cannot use, it is not the most restrictive)
+# |-----------|
+# | 2  pdus   |  <----- PREDICTION (USE THIS -- it is the most restrictive prediction, and better than icus)
+# |-----------|
+# | 1  icus   |  <----- CURRENT RIGHTS
+# |-----------|
+# | 0   ic    |
+# |-----------|
+#
+# In a nutshell: choose minimum prediction and return it if it is greater than current rights
+sub choose_rights_prediction {
+  my $self        = shift;
+  my $attribute   = shift; # current rights attr string
+  my $predictions = shift;
+
+  # This map allows us to grade the current rights and the predictions into 0-3 as above.
+  my $attr_values = {'pd' => 3, 'pdus' => 2, 'icus' => 1, 'ic' => 0};
+
+  # Get the value for current rights.
+  # It should not be terribly unusual to find current rights outside the pd/pdus/icus/ic contionuum
+  # although we will filter many of these out with `are_rights_in_scope` above.
+  # However, that does allow through rights like und/nfi (at least historically, we no longer export
+  # these to the rights DB by default).
+  # We can bail out if we get something outside the expected main four attributes.
+  my $current_value = $attr_values->{$attribute};
+  return unless defined $current_value;
+
+  # Expand predictions into array of { prediction => "attr/reason", value => value }
+  my @values = map {
+    my ($a, $r) = split('/', $_);
+    { prediction => $_, value => $attr_values->{$a} };
+  } keys %$predictions;
+
+  # Extract out the "minimum" prediction, conflating undefs (unknown prediction) with ic,
+  # neither of which we can return as a viable choice.
+  my $min = List::Util::reduce {
+    ($a->{value} || 0) < ($b->{value} || 0) ? $a : $b;
+  } @values;
+
+  # Bail out if there were no predictions, or if the best we can do is undef/ic
+  if (!$min || !$min->{value}) {
+    return;
+  }
+
+  # Compare the values. If the predicted is greater than current, return that.
+  # This will be the benefit of the new year rollover in terms of less restrictive rights.
+  if ($min->{value} > $current_value) {
+    return $min->{prediction};
+  }
+  return;
 }
 
 1;

--- a/t/lib/CRMS/NewYear.t
+++ b/t/lib/CRMS/NewYear.t
@@ -1,0 +1,96 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More;
+
+use lib $ENV{'SDRROOT'} . '/crms/lib';
+use CRMS::NewYear;
+
+my $new_year = CRMS::NewYear->new;
+
+subtest 'new' => sub {
+  isa_ok($new_year, 'CRMS::NewYear');
+};
+
+# Note: here we are testing all 59 attested attr/reason combinations attested in rights_current
+# at time of writing. Some of these are a little head scratchy.
+subtest 'are_rights_in_scope' => sub {
+  subtest 'with in-scope rights combinations' => sub {
+    my $in_scope = [
+      'ic/add',
+      'ic/bib',
+      'ic/cdpp',
+      'ic/crms',
+      'ic/ipma',
+      'icus/gatt',
+      'icus/ren',
+      'op/ipma',
+      'pdus/add',
+      'pdus/bib',
+      'pdus/cdpp',
+      'pdus/crms',
+      'pdus/gfv',
+      'pdus/ncn',
+      'pdus/ren',
+      'pdus/ncn',
+      'und/bib',
+      'und/crms',
+      'und/ipma',
+      'und/nfi',
+      'und/ren',
+    ];
+    foreach my $rights (@$in_scope) {
+      my ($attribute, $reason) = split('/', $rights);
+      ok($new_year->are_rights_in_scope($attribute, $reason), "$rights is in scope");
+    }
+  };
+
+  subtest 'with out-of-scope rights combinations' => sub {
+    my $out_of_scope = [
+      'cc-by-3.0/con',
+      'cc-by-3.0/man',
+      'cc-by-4.0/con',
+      'cc-by-4.0/man',
+      'cc-by-nc-3.0/con',
+      'cc-by-nc-3.0/man',
+      'cc-by-nc-4.0/con',
+      'cc-by-nc-4.0/man',
+      'cc-by-nc-nd-3.0/con',
+      'cc-by-nc-nd-4.0/con',
+      'cc-by-nc-nd-4.0/man',
+      'cc-by-nc-sa-3.0/con',
+      'cc-by-nc-sa-4.0/con',
+      'cc-by-nd-3.0/con',
+      'cc-by-nd-4.0/con',
+      'cc-by-sa-3.0/con',
+      'cc-by-sa-4.0/con',
+      'cc-zero/con',
+      'ic-world/con',
+      'ic-world/man',
+      'nobody/del',
+      'nobody/man',
+      'nobody/pvt',
+      'pd/add',
+      'pd/bib',
+      'pd/cdpp',
+      'pd/con',
+      'pd/crms',
+      'pd/exp',
+      'pd/man',
+      'pd/ncn',
+      'pd/ren',
+      'pdus/man',
+      'pd-pvt/pvt',
+      'supp/supp',
+      'und-world/con',
+    ];
+    foreach my $rights (@$out_of_scope) {
+      my ($attribute, $reason) = split('/', $rights);
+      ok(!$new_year->are_rights_in_scope($attribute, $reason), "$rights is out of scope");
+    }
+  };
+};
+
+done_testing();

--- a/t/lib/CRMS/NewYear.t
+++ b/t/lib/CRMS/NewYear.t
@@ -93,4 +93,49 @@ subtest 'are_rights_in_scope' => sub {
   };
 };
 
+subtest 'choose_rights_prediction' => sub {
+  subtest 'with no predictions' => sub {
+    my $predictions = {};
+    my $res = $new_year->choose_rights_prediction('ic', $predictions);
+    ok(!defined $res, 'no prediction');
+  };
+
+  subtest 'with minimum prediction greater than current rights' => sub {
+    my $predictions = {'pd/add' => 1, 'pdus/exp' => 1, 'icus/gatt' => 1};
+    my $res = $new_year->choose_rights_prediction('ic', $predictions);
+    is($res, 'icus/gatt', 'ic moves up to icus/gatt');
+  };
+
+  subtest 'with minimum prediction same as current rights' => sub {
+    my $predictions = {'pd/add' => 1};
+    my $res = $new_year->choose_rights_prediction('pd', $predictions);
+    ok(!defined $res, 'no prediction');
+  };
+
+  subtest 'with minimum prediction less than current rights' => sub {
+    my $predictions = {'pdus/add' => 1, 'icus/gatt' => 1};
+    my $res = $new_year->choose_rights_prediction('pd', $predictions);
+    ok(!defined $res, 'no prediction');
+  };
+  subtest 'edge cases' => sub {
+    subtest 'nonsense prediction' => sub {
+      my $predictions = {'xxx/yyy' => 1, 'ic/ren' => 1};
+      my $res = $new_year->choose_rights_prediction('pdus', $predictions);
+      ok(!defined $res, 'no prediction');
+    };
+
+    subtest 'nonsense prediction part deux' => sub {
+      my $predictions = {'xxx/yyy' => 1, 'ic/ren' => 1, 'pdus/ren' => 1};
+      my $res = $new_year->choose_rights_prediction('pd', $predictions);
+      ok(!defined $res, 'no prediction');
+    };
+
+    subtest 'out of scope current rights' => sub {
+      my $predictions = {'pdus/add' => 1};
+      my $res = $new_year->choose_rights_prediction('und', $predictions);
+      ok(!defined $res, 'no prediction');
+    };
+  };
+};
+
 done_testing();


### PR DESCRIPTION
- Add `NewYear` module with tests for `are_rights_in_scope` extracted and expanded from what is in bin/newyear.pl
  - I have checked the items listed in the tests, which are comprehensive, with KH to get confirmation this is the correct list.
- Add `CRMS::NewYear` method `choose_rights_prediction`
  - This is intended to replace one of the nastiest blocks of code encountered in `bin/newyear.pl` around lines 198-215 and duplicated at 359-376.
  - Much depends on this being comprehensible and working as intended, so this is an attempt to get a better handle on it. Currently this new method is not called anywhere. I would like to do an A/B comparison between the two methods of comparing PDD rights predictions.

KH and I have examined and discussed both methods in the new module and are in agreement that what is here seems right as long as nothing peculiar emerges in the A/B comparison (which should be done by Nov 7 -- it's a time consuming script to run twice). [Edit: see below on result of A/B]

I am now convinced `choose_rights_prediction` should be wired into `newyear.pl` as part of this branch.