### PR TITLE
ETT-825 Operational bug: CRMS order-by

### DIFF
--- a/bin/debug_user.pl
+++ b/bin/debug_user.pl
@@ -1,0 +1,66 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use utf8;
+
+BEGIN {
+  die "SDRROOT environment variable not set" unless defined $ENV{'SDRROOT'};
+  use lib $ENV{'SDRROOT'} . '/crms/cgi';
+}
+
+#use Encode;
+use Getopt::Long qw(:config no_ignore_case bundling);
+use Data::Dumper;
+#use File::Slurp;
+#use MARC::Record;
+#use MARC::File::XML(BinaryEncoding => 'utf8');
+
+#use BibRights;
+
+binmode(STDOUT, ':encoding(UTF-8)');
+
+my $usage = <<END;
+USAGE: $0 [-hp] [-i path/to/file] [htid_or_cid_1 [htid_or_cid_2 ...]]
+
+Reports on the volumes to queued up next for a given reviewer.
+This is mainly for debugging purposes.
+
+-h, -?    Print this help message.
+-p         Run in production.
+-t      Run in training.
+END
+
+my $instance;
+my $help;
+my $production;
+my $training;
+
+Getopt::Long::Configure('bundling');
+die 'Terminating' unless GetOptions(
+  'h|?'  => \$help,
+  'p'    => \$production,
+  't'    => \$training,
+);
+
+if ($help) { print $usage. "\n"; exit(0); }
+
+$instance = 'production' if $production;
+$instance = 'crms-training' if $training;
+
+die "Please provide a single user id" unless 1 == scalar @ARGV;
+my $user = $ARGV[0];
+
+my $crms = CRMS->new(instance => $instance);
+
+my $ref = $crms->select_from_queue_for_user($user);
+foreach my $row (@$ref) {
+  my ($htid, $count, $hash, $priority, $project, $sysid) = @$row;
+
+  printf "$htid ($sysid) [%s] %s ($count, %s...) (P %s Proj %s)\n",
+    $crms->GetAuthor($htid) || '',
+    $crms->GetTitle($htid) || '',
+    uc substr($hash, 0, 8),
+    $priority,
+    $project;
+}

--- a/t/CRMS.t
+++ b/t/CRMS.t
@@ -144,6 +144,45 @@ subtest '#UpdateMetadata' => sub {
   delete $ENV{CRMS_METADATA_FIXTURES_PATH};
 };
 
+subtest 'GetNextItemForReview' => sub {
+  $ENV{CRMS_METADATA_FIXTURES_PATH} = $ENV{'SDRROOT'} . '/crms/t/fixtures/metadata';
+  my $htid = 'coo.31924000029250';
+  my $record = Metadata->new('id' => $htid);
+  $crms->UpdateMetadata($htid, 1, $record);
+  $crms->PrepareSubmitSql('INSERT INTO queue (id,project) VALUES (?,?)', $htid, 1);
+  # Assign autocrms to this project
+  $crms->PrepareSubmitSql('INSERT INTO projectusers (project,user) VALUES (?,?)',1, 'autocrms');
+  $crms->PrepareSubmitSql('UPDATE users SET project=1 WHERE id=?', 'autocrms');
+  $crms->ClearErrors;
+  my $next_volume = $crms->GetNextItemForReview('autocrms');
+  is($next_volume, $htid, 'expected volume is returned');
+  $crms->PrepareSubmitSql('DELETE FROM projectusers');
+  $crms->PrepareSubmitSql('DELETE FROM queue');
+  $crms->PrepareSubmitSql('DELETE FROM bibdata');
+  delete $ENV{CRMS_METADATA_FIXTURES_PATH};
+};
+
+subtest 'select_from_queue_for_user' => sub {
+  $ENV{CRMS_METADATA_FIXTURES_PATH} = $ENV{'SDRROOT'} . '/crms/t/fixtures/metadata';
+  my $htid = 'coo.31924000029250';
+  my $record = Metadata->new('id' => $htid);
+  $crms->UpdateMetadata($htid, 1, $record);
+  $crms->PrepareSubmitSql('INSERT INTO queue (id,project) VALUES (?,?)', $htid, 1);
+  # Assign autocrms to this project
+  $crms->PrepareSubmitSql('INSERT INTO projectusers (project,user) VALUES (?,?)',1, 'autocrms');
+  $crms->PrepareSubmitSql('UPDATE users SET project=1 WHERE id=?', 'autocrms');
+  $crms->ClearErrors;
+  my $result = $crms->select_from_queue_for_user('autocrms');
+  ok(defined $result->{data}, 'there is result data');
+  ok(defined $result->{sql}, 'there is result sql');
+  ok(defined $result->{params}, 'there is result query params');
+  is($result->{data}->[0]->[0], $htid, 'expected volume is returned');
+  $crms->PrepareSubmitSql('DELETE FROM projectusers');
+  $crms->PrepareSubmitSql('DELETE FROM queue');
+  $crms->PrepareSubmitSql('DELETE FROM bibdata');
+  delete $ENV{CRMS_METADATA_FIXTURES_PATH};
+};
+
 subtest '#LinkToJira' => sub {
   is($crms->LinkToJira('DEV-000'),
     '<a href="https://hathitrust.atlassian.net/browse/DEV-000" target="_blank">DEV-000</a>');


### PR DESCRIPTION
 - The issue in a nutshell: `CRMS::GetNextItemForReview` is placing project-specific result ORDER BY first, overriding the two most critical presentation orders (priority and number of reviews already done) leaving some existing single-review items in limbo.
 - `GetNextItemForReview` is another monolithic "wall of code"
   - Split the SQL bits of `GetNextItemForReview` into a new child method `select_from_queue_for_user` and leave the iteration logic in the original method.
   - Add VERY basic test for each method.
   - The `select_from_queue_for_user` method is now a good entrypoint for debugging so remove some built-in debugging code (the `$test` param) into a new utility `bin/debug_user.pl`
 - Solve the original problem by splitting the `@orders` array into `@critical_order` and `@noncritical_order`. Project orders get sandwiched in the middle. I guess they could go anywhere as long as they aren't unshifted onto the critical array.
 - Testing the added code is a bit of a dilemma. We don't have a bunch of representative data and faking up something that actually exercises code that is intended for largish data sets is a bit of a nightmare.
 - I'm inclined to leave this only superficially tested, and take comfort in the fact that the situation is marginally better than before.