### PR TITLE
ETT-825 Operational bug: CRMS order-by

### DIFF
--- a/t/CRMS.t
+++ b/t/CRMS.t
@@ -144,6 +144,24 @@ subtest '#UpdateMetadata' => sub {
   delete $ENV{CRMS_METADATA_FIXTURES_PATH};
 };
 
+subtest 'GetNextItemForReview' => sub {
+  $ENV{CRMS_METADATA_FIXTURES_PATH} = $ENV{'SDRROOT'} . '/crms/t/fixtures/metadata';
+  my $htid = 'coo.31924000029250';
+  my $record = Metadata->new('id' => $htid);
+  $crms->UpdateMetadata($htid, 1, $record);
+  $crms->PrepareSubmitSql('INSERT INTO queue (id,project) VALUES (?,?)', $htid, 1);
+  # Assign autocrms to this project
+  $crms->PrepareSubmitSql('INSERT INTO projectusers (project,user) VALUES (?,?)',1, 'autocrms');
+  $crms->PrepareSubmitSql('UPDATE users SET project=1 WHERE id=?', 'autocrms');
+  $crms->ClearErrors;
+  my $next_volume = $crms->GetNextItemForReview('autocrms');
+  is($next_volume, $htid, 'expected volume is returned');
+  $crms->PrepareSubmitSql('DELETE FROM projectusers');
+  $crms->PrepareSubmitSql('DELETE FROM queue');
+  $crms->PrepareSubmitSql('DELETE FROM bibdata');
+  delete $ENV{CRMS_METADATA_FIXTURES_PATH};
+};
+
 subtest '#LinkToJira' => sub {
   is($crms->LinkToJira('DEV-000'),
     '<a href="https://hathitrust.atlassian.net/browse/DEV-000" target="_blank">DEV-000</a>');

--- a/t/CRMS.t
+++ b/t/CRMS.t
@@ -151,7 +151,7 @@ subtest 'GetNextItemForReview' => sub {
   $crms->UpdateMetadata($htid, 1, $record);
   $crms->PrepareSubmitSql('INSERT INTO queue (id,project) VALUES (?,?)', $htid, 1);
   # Assign autocrms to this project
-  $crms->PrepareSubmitSql('INSERT INTO projectusers (project,user) VALUES (?,?)',1, 'autocrms');
+  $crms->PrepareSubmitSql('INSERT INTO projectusers (project,user) VALUES (?,?)', 1, 'autocrms');
   $crms->PrepareSubmitSql('UPDATE users SET project=1 WHERE id=?', 'autocrms');
   $crms->ClearErrors;
   my $next_volume = $crms->GetNextItemForReview('autocrms');


### PR DESCRIPTION
This seems to be about the smallest bugfix PR I am capable of producing. Has been tested on dev-2 against the production database and the results are now correct.

- Fix ordering in `CRMS::GetNextItemForReview`
   - Split `ORDER BY` parameters into "critical" and "noncritical"
   - Any project-supplied `ORDER BY`s get prepended to the noncritical array.
- Remove obsolete comment.
- Add `params` arrays for both of the new arrays to address an existing (and commented-on) parameter land mine. This helps ensure clauses and their parameters get assembled in the right order.
- Add a very basic test for `GetNextItemForReview` that, alas, doesn't really test the bugfix, just that the code can still produce a correct output.

### For the Reviewer
In a nutshell, CRMS is calling `SELECT ... FROM queue WHERE ...` with a bunch of `ORDER BY` constraints and the optional `ORDER` called `$porder` needs to be in the middle of the list. Hence the split into "critical" and "noncritical".

The added `@critical_order_params` and `@noncritical_order_params` is insurance against future bugs, it is not really part of the bugfix. The existing parameter handling was just... not nice.