### PR TITLE
Use Debain 13 "trixie"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,162 +1,43 @@
-FROM debian:bullseye
-
-RUN sed -i 's/main.*/main contrib non-free/' /etc/apt/sources.list
+FROM debian:trixie
 
 RUN apt-get update && apt-get install -y \
-  perl \
-  libxerces-c3.2 \
-  libxerces-c3-dev \
-  sqlite3 \
+  cpanminus \
   file \
-  libalgorithm-diff-xs-perl \
-  libany-moose-perl \
-  libapache-session-perl \
-  libarchive-zip-perl \
+  git \
   libcapture-tiny-perl \
-  libcgi-application-perl \
-  libcgi-compile-perl \
-  libcgi-emulate-psgi-perl \
-  libcgi-psgi-perl \
-  libclass-accessor-perl \
-  libclass-c3-perl \
-  libclass-data-accessor-perl \
-  libclass-data-inheritable-perl \
-  libclass-errorhandler-perl \
-  libclass-load-perl \
-  libcommon-sense-perl \
-  libcompress-raw-zlib-perl \
-  libconfig-auto-perl \
-  libconfig-inifiles-perl \
-  libconfig-tiny-perl \
-  libcrypt-openssl-random-perl \
-  libcrypt-openssl-rsa-perl \
-  libcrypt-ssleay-perl \
-  libdata-optlist-perl \
+  libcgi-pm-perl \
   libdata-page-perl \
   libdate-calc-perl \
   libdate-manip-perl \
-  libdbd-mock-perl \
   libdbd-mysql-perl \
-  libdbd-sqlite3-perl \
-  libdevel-globaldestruction-perl \
-  libdigest-sha-perl \
-  libemail-date-format-perl \
-  libencode-locale-perl \
-  liberror-perl \
-  libeval-closure-perl \
-  libexcel-writer-xlsx-perl \
-  libfcgi-perl \
-  libfcgi-procmanager-perl \
-  libfile-listing-perl \
+  libdevel-cover-perl \
   libfile-slurp-perl \
-  libfilesys-df-perl \
-  libgeo-ip-perl \
-  libhtml-parser-perl \
-  libhtml-tree-perl \
-  libhttp-browserdetect-perl \
-  libhttp-cookies-perl \
-  libhttp-daemon-perl \
-  libhttp-date-perl \
-  libhttp-dav-perl \
-  libhttp-message-perl \
-  libhttp-negotiate-perl \
-  libimage-exiftool-perl \
-  libimage-info-perl \
-  libimage-size-perl \
-  libinline-perl \
-  libio-html-perl \
-  libio-socket-ssl-perl \
-  libio-string-perl \
   libipc-run-perl \
-  libjson-perl \
-  libjson-pp-perl \
   libjson-xs-perl \
-  liblist-compare-perl \
-  liblist-moreutils-perl \
   liblog-log4perl-perl \
-  liblwp-authen-oauth2-perl \
   liblwp-mediatypes-perl \
   libmail-sendmail-perl \
-  libmailtools-perl \
-  libmime-lite-perl \
-  libmime-types-perl \
-  libmodule-implementation-perl \
-  libmodule-runtime-perl \
-  libmoose-perl \
-  libmouse-perl \
-  libmro-compat-perl \
-  libnet-dns-perl \
   libnet-http-perl \
-  libnet-libidn-perl \
-  libnet-oauth-perl \
-  libnet-ssleay-perl \
-  libpackage-deprecationmanager-perl \
-  libpackage-stash-perl \
-  libparse-recdescent-perl \
-  libplack-perl \
-  libpod-simple-perl \
-  libproc-processtable-perl \
-  libreadonly-perl \
-  libreadonly-xs-perl \
-  libroman-perl \
-  libsoap-lite-perl \
-  libspreadsheet-writeexcel-perl \
-  libsub-exporter-progressive-perl \
-  libsub-name-perl \
+  libperl-critic-perl \
   libtemplate-perl \
-  libterm-readkey-perl \
-  libterm-readline-gnu-perl \
-  libtest-requiresinternet-perl \
-  libtest-simple-perl \
-  libtie-ixhash-perl \
+  libtest-exception-perl \
+  libtest-lwp-useragent-perl \
   libtimedate-perl \
   libtry-tiny-perl \
-  libuniversal-require-perl \
   liburi-encode-perl \
   libuuid-perl \
   libuuid-tiny-perl \
-  libversion-perl \
   libwww-perl \
-  libwww-robotrules-perl \
-  libxml-dom-perl \
   libxml-libxml-perl \
-  libxml-libxslt-perl \
-  libxml-sax-perl \
-  libxml-simple-perl \
-  libxml-writer-perl \
-  libyaml-appconfig-perl \
-  libyaml-libyaml-perl \
   libyaml-perl \
   libmarc-record-perl \
-  libmarc-xml-perl
-
-RUN apt-get install -y \
-  autoconf \
-  bison \
-  build-essential \
-  cpanminus \
-  git \
-  libdevel-cover-perl \
-  libffi-dev \
-  libgdbm-dev \
-  libncurses5-dev \
-  libperl-critic-perl \
-  libreadline6-dev \
-  libsqlite3-dev \
-  libssl-dev \
-  libyaml-dev \
-  openssh-server \
-  unzip \
-  wget \
-  zip \
-  zlib1g-dev
+  libmarc-xml-perl \
+  perl \
+  wget
 
 RUN cpanm --notest \
   Devel::Cover::Report::Coveralls \
-  MARC::Record::MiJ \
-  OAuth::Lite \
-  Test::Exception \
-  Test::LWP::UserAgent
+  MARC::Record::MiJ
 
 ENV SDRROOT /htapps/babel
 ENV ROOTDIR "${SDRROOT}/crms"

--- a/cgi/CRMS.pm
+++ b/cgi/CRMS.pm
@@ -7908,6 +7908,7 @@ sub SubmitMail
   $self->PrepareSubmitSql($sql, $id, $user, $text, $uuid, $to, $wait);
 }
 
+# DEPRECATED. Remove UUID::Tiny from Dockerfile and use CRMS::Utility::Data::uuid instead.
 sub UUID
 {
   my $self = shift;

--- a/lib/CRMS/Utility.pm
+++ b/lib/CRMS/Utility.pm
@@ -1,0 +1,32 @@
+package CRMS::Utility;
+
+use strict;
+use warnings;
+use utf8;
+
+use lib "$ENV{SDRROOT}/crms/lib";
+use CRMS::Utility::Data qw();
+
+# This is a stateless class so it's fine for the singleton pattern.
+my $ONE_TRUE_UTILITY;
+
+sub new {
+  my ($class, %args) = @_;
+  my $self = bless {}, $class;
+
+  if (!defined $ONE_TRUE_UTILITY) {
+    $ONE_TRUE_UTILITY = $self;
+  }
+  return $ONE_TRUE_UTILITY;
+}
+
+sub data {
+  my $self = shift;
+
+  if (!defined $self->{data}) {
+    $self->{data} = CRMS::Utility::Data->new;
+  }
+  return $self->{data};
+}
+
+1;

--- a/lib/CRMS/Utility/Data.pm
+++ b/lib/CRMS/Utility/Data.pm
@@ -1,0 +1,30 @@
+package CRMS::Utility::Data;
+
+use strict;
+use warnings;
+use utf8;
+
+use UUID qw();
+
+# This is a stateless class so it's fine for the singleton pattern.
+my $ONE_TRUE_UTILITY_DATA;
+
+sub new {
+  my ($class, %args) = @_;
+  my $self = bless {}, $class;
+
+  if (!defined $ONE_TRUE_UTILITY_DATA) {
+    $ONE_TRUE_UTILITY_DATA = $self;
+  }
+  return $ONE_TRUE_UTILITY_DATA;
+}
+
+# TODO: deprecate CRMS::UUID in favor of this method.
+sub uuid {
+  my $self = shift;
+
+  return UUID::uuid4;
+}
+
+1;
+

--- a/t/CRMS.t
+++ b/t/CRMS.t
@@ -187,8 +187,11 @@ subtest '#GetProjectsRef' => sub {
   isa_ok($crms->GetProjectsRef, 'ARRAY');
 };
 
-subtest '#Field008Formatter' => sub {
-  isa_ok $crms->Field008Formatter, "CRMS::Field008Formatter";
+subtest '#UUID' => sub {
+  ok(
+    $crms->UUID =~ m/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/,
+    'UUID matches expected format'
+  );
 };
 
 subtest '#Field008Formatter' => sub {

--- a/t/lib/CRMS/Utility.t
+++ b/t/lib/CRMS/Utility.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+use utf8;
+
+use Test::Exception;
+use Test::More;
+
+use lib "$ENV{SDRROOT}/crms/lib";
+
+use CRMS::Utility;
+
+subtest '#new' => sub {
+  ok(defined CRMS::Utility->new);
+};
+
+subtest '#data' => sub {
+  ok(defined CRMS::Utility->new->data);
+};
+
+done_testing();

--- a/t/lib/CRMS/Utility/Data.t
+++ b/t/lib/CRMS/Utility/Data.t
@@ -1,0 +1,24 @@
+use strict;
+use warnings;
+use utf8;
+
+use Test::Exception;
+use Test::More;
+
+use lib "$ENV{SDRROOT}/crms/lib";
+
+use CRMS::Utility::Data;
+
+subtest '#new' => sub {
+  ok(defined CRMS::Utility::Data->new);
+};
+
+subtest '#uuid' => sub {
+  my $uuid = CRMS::Utility::Data->new->uuid;
+  ok(
+    $uuid =~ m/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/,
+    'UUID matches expected format'
+  );
+};
+
+done_testing();


### PR DESCRIPTION
### Part one:
Use Debian 13 image
 - Remove unused apt and CPAN dependencies
 - Consolidate apt packages
 - Move some dependencies from cpanm to apt

### Part two:
The jumping-off point for this "pre-refactor" is the abandoned `UUID::Tiny` module and the question of why the core `CRMS` module is responsible for things like UUIDs (and Dates, Pluralization, Number Formatting...).

One of the reasons CRMS is so bloated is: it is one of the only objects the Template Toolkit templates have access to. As a result, all manner of utility routines and glue have accreted there. It's an uber controller/presenter/helper class in one gargantuan package.

The plan will be to incrementally migrate utilities into `lib/CRMS` and get them fully tested, and ultimately provide a `utility` singleton to all the various page templates the same way we provide a `CRMS` object. TT templates can call procedural routines, but not in a very nice way. There's no such thing as "just" loading a module and calling `new`, or a procedural `sub`.

This commit is to be a placeholder showing how to do some of the next refactoring steps without affecting the behavior of the current system. I'm providing a `uuid` method from the new classes so we can give the old one the heave-ho and get rid of `UUID::Tiny` in the near future.