### PR TITLE
Restrict debugging

### DIFF
--- a/cgi/CRMS.pm
+++ b/cgi/CRMS.pm
@@ -59,13 +59,11 @@ sub new
     print "<strong>Warning: no CGI passed to <code>CRMS->new()</code>\n" unless $cgi;
     $self->set('cgi',      $cgi);
     $self->set('debugSql', $args{'debugSql'});
-    $self->set('debugVar', $args{'debugVar'});
     $self->SetupUser();
     if ($cgi->param('debugAuth')) {
       $self->AuthDebugData;
     }
   }
-  $self->DebugVar('self', $self);
   return $self;
 }
 
@@ -558,35 +556,6 @@ sub DebugSql
     </div>
 END
     my $msg = sprintf $html, join(',', @_), $time;
-    my $storedDebug = $self->get('storedDebug') || '';
-    $self->set('storedDebug', $storedDebug. $msg);
-    $ct++;
-    $self->set('debugCount', $ct);
-  }
-}
-
-sub DebugVar
-{
-  my $self = shift;
-  my $var  = shift;
-  my $val  = shift;
-
-  my $debug = $self->get('debugVar');
-  if ($debug)
-  {
-    my $ct = $self->get('debugCount') || 0;
-	  my $html = <<END;
-    <div class="debug">
-      <div class="debugVar" onClick="ToggleDiv('details$ct', 'debugVarDetails');">
-        VAR $var
-      </div>
-      <div id="details$ct" class="divHide"
-           style="background-color: #fcc;" onClick="ToggleDiv('details$ct', 'debugVarDetails');">
-        %s
-      </div>
-    </div>
-END
-    my $msg = sprintf $html, Dumper($val);
     my $storedDebug = $self->get('storedDebug') || '';
     $self->set('storedDebug', $storedDebug. $msg);
     $ct++;

--- a/cgi/CRMS.pm
+++ b/cgi/CRMS.pm
@@ -61,6 +61,9 @@ sub new
     $self->set('debugSql', $args{'debugSql'});
     $self->set('debugVar', $args{'debugVar'});
     $self->SetupUser();
+    if ($cgi->param('debugAuth')) {
+      $self->AuthDebugData;
+    }
   }
   $self->DebugVar('self', $self);
   return $self;
@@ -591,46 +594,14 @@ END
   }
 }
 
-sub DebugAuth
-{
-  my $self = shift;
-
-  my $debug = $self->get('debugAuth');
-  if ($debug)
-  {
-    my $ct = $self->get('debugCount') || 0;
-	  my $html = <<END;
-    <div class="debug">
-      <div class="debugVar" onClick="ToggleDiv('details$ct', 'debugVarDetails');">
-        AUTH
-      </div>
-      <div id="details$ct" class="divHide"
-           style="background-color: #fcc;" onClick="ToggleDiv('details$ct', 'debugVarDetails');">
-        %s
-      </div>
-    </div>
-END
-    my $storedDebug = $self->get('storedDebug') || '';
-    $self->set('storedDebug', $storedDebug. $self->AuthDebugHTML());
-    $ct++;
-    $self->set('debugCount', $ct);
-  }
-}
-
+# Log auth debugging information to the crms.note table.
 sub AuthDebugData
 {
   my $self = shift;
-  my $html = shift;
 
   my $note1 = $self->get('id_note') || '';
   my $note2 = $self->get('auth_note') || '';
-  my $msg = $note1. "\n". $note2;
-  if ($html)
-  {
-    $msg = CGI::escapeHTML($msg);
-    $msg =~ s/\n+/<br\/>/gs;
-  }
-  return $msg;
+  $self->Note($note1 . "\n" . $note2);
 }
 
 # Called to return and flush any accumulated debugging display.

--- a/cgi/crms
+++ b/cgi/crms
@@ -35,6 +35,8 @@ my $redirect;
 my $uri = $ENV{'REQUEST_URI'};
 $uri =~ s/&/;/g;
 my $target = uri_escape_utf8('https://'. $ENV{'HTTP_HOST'}. $uri);
+# remote_user is the crms.users primary key
+# If not set, may be authenticated with ht.ht_users but not in the CRMS system
 if (!$crms->get('remote_user'))
 {
   $redirect = 'https://'. $ENV{'HTTP_HOST'}. "/cgi/wayf?target=$target";
@@ -43,6 +45,14 @@ if ($crms->get('stepup') && $crms->get('stepup_redirect'))
 {
   $redirect = $crms->get('stepup_redirect');
 }
+
+# If $redirect is set then the user is unauthenticated
+# Emit the redirect immediately and terminate
+if ($redirect) {
+  print $cgi->redirect($redirect);
+  exit;
+}
+
 if ($page eq 'Logout')
 {
   # Remove all locks for this user.
@@ -59,6 +69,8 @@ if ($page eq 'Logout')
     $crms->UnlockAllItemsForUser();
     $target =~ s/logout/home/gi;
     $redirect = 'https://' . $ENV{'HTTP_HOST'} . '/cgi/logout?' . $target;
+    print $cgi->redirect($redirect);
+    exit;
   }
 }
 elsif ($cgi->param('changeuser') == 1)
@@ -66,6 +78,7 @@ elsif ($cgi->param('changeuser') == 1)
   $crms->SetAlias(undef, $cgi->param('newuser'));
   $cgi->delete_all();
 }
+
 my $user = $crms->get('user');
 
 ### Review submission: all projects go through here.
@@ -110,17 +123,6 @@ if ($page eq 'finishReview')
     print '<script type="text/javascript">window.close();</script>';
     exit(0);
   }
-}
-
-if ($redirect && !$debugAuth)
-{
-  if ($crms->GetSystemVar('logAuth'))
-  {
-    my $db = $crms->AuthDebugData();
-    $crms->Note($db);
-  }
-  print $cgi->redirect($redirect);
-  exit(0);
 }
 
 if ($cgi->param('download'))

--- a/cgi/crms
+++ b/cgi/crms
@@ -20,14 +20,12 @@ use CRMS;
 binmode(STDOUT, ':encoding(UTF-8)');
 my $cgi = new CGI;
 my $page = $cgi->param('p');
-my $debugAuth = $cgi->param('debugAuth');
 my $debugSql = $cgi->param('debugSql');
 my $debugVar = $cgi->param('debugVar');
 my $debug = $cgi->param('debug');
 my $crms = CRMS->new(
         cgi       => $cgi,
         verbose   => 0,
-        debugAuth => $debugAuth,
         debugSql  => $debugSql,
         debugVar  => $debugVar
         );
@@ -196,17 +194,6 @@ if (!$tt->process($input, $vars))
   die $tt->error();
 }
 print $crms->Debug();
-if ($debugAuth)
-{
-  my $db = $crms->AuthDebugData(1);
-  print <<END;
-<div>
-    <h2>Auth Debug</h2>
-    <span style="color:black;"><code>$db</code></span>
-  </div>
-END
-}
-
 if ($debug)
 {
   print "<div class=\"debug-footer\">\n<h3>Debug Information</h3>\n";

--- a/cgi/crms
+++ b/cgi/crms
@@ -9,7 +9,6 @@ BEGIN {
 }
 
 use CGI;
-use Data::Dumper;
 use Encode;
 use POSIX;
 use Template;
@@ -22,7 +21,6 @@ my $cgi = new CGI;
 my $page = $cgi->param('p');
 my $debugSql = $cgi->param('debugSql');
 my $debugVar = $cgi->param('debugVar');
-my $debug = $cgi->param('debug');
 my $crms = CRMS->new(
         cgi       => $cgi,
         verbose   => 0,
@@ -193,11 +191,20 @@ if (!$tt->process($input, $vars))
   printf "<h3>%s</h3>\n", $tt->error();
   die $tt->error();
 }
+
+# Debugging output is restricted to development instance
+exit if CRMS::Config->new->instance ne 'development';
+
+# Print accumulated output of DebugSql calls
 print $crms->Debug();
-if ($debug)
+
+# Print diagnostics with debug URL parameter
+if ($cgi->param('debug'))
 {
   print "<div class=\"debug-footer\">\n<h3>Debug Information</h3>\n";
   eval {
+    use Data::Dumper;
+
     printf 'Host: <b>%s</b><br/>', `hostname`;
     my $dbinfo = $crms->DbInfo();
     $dbinfo =~ s/\n/<br\/>/g;

--- a/cgi/crms
+++ b/cgi/crms
@@ -20,12 +20,10 @@ binmode(STDOUT, ':encoding(UTF-8)');
 my $cgi = new CGI;
 my $page = $cgi->param('p');
 my $debugSql = $cgi->param('debugSql');
-my $debugVar = $cgi->param('debugVar');
 my $crms = CRMS->new(
         cgi       => $cgi,
         verbose   => 0,
-        debugSql  => $debugSql,
-        debugVar  => $debugVar
+        debugSql  => $debugSql
         );
 my $redirect;
 my $uri = $ENV{'REQUEST_URI'};

--- a/cgi/denied.tt
+++ b/cgi/denied.tt
@@ -30,5 +30,4 @@
       </h4>
     </div>
   </div>
-  [% CALL cgi.param('debugAuth', 1) %]
 [% INCLUDE footer.tt %]

--- a/cgi/header.tt
+++ b/cgi/header.tt
@@ -10,7 +10,7 @@
   [% IF reviewType %]
     <script src="[% crms.WebPath('web', 'js/review.js') %]"></script>
   [% END %]
-  [% IF crms.get('debugSql') || crms.get('debugVar') %]
+  [% IF crms.get('debugSql') %]
     <link rel="stylesheet" type="text/css" href="[% crms.WebPath('web', 'css/debug.css') %]"/>
   [% END %]
   [% IF page == 'exportStats' %]

--- a/web/css/debug.css
+++ b/web/css/debug.css
@@ -33,22 +33,6 @@
 	text-align: left;
 }
 
-.debugVar {
-	background-color: #c99;
-	color: #FFF;
-	font-weight: bold;
-	padding: 0 20px 0 20px;
-	text-align: left;
-}
-
-.debugVarDetails {
-	background-color: #fcc;
-	color: #000;
-	padding: 0 20px 0 20px; 
-	border-top: 1px solid #999;
-	text-align: left;
-}
-
 .debugErr {
 	background-color: #900;
 	font-weight: bold;


### PR DESCRIPTION
Based on an internal discussion. Highlights of this PR (the first bullet point is the important one):
- Restrict `debugAuth` debugging output to internal table
  - Redirect immediately to wayf when access is unauthenticated
- Restrict remaining debug print-to-HTML functionality to `development` instance (dev VMs and Docker)
- Remove support for minimally-used `debugVar` URL param

Available for testing on dev-2
